### PR TITLE
 Cập nhật giao diện mới cho đẹp hơn

### DIFF
--- a/src/resources/css/app.css
+++ b/src/resources/css/app.css
@@ -1,4 +1,5 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Be+Vietnam+Pro:wght@400;500;600;700;800&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap');
 
 @tailwind base;
@@ -47,22 +48,19 @@
 
     /* Sidebar nav item base style */
     .sidebar-link {
-        @apply flex items-center gap-3 px-4 py-2.5 text-sm font-black uppercase tracking-wide text-slate-800 bg-white border-[2px] border-black transition-all duration-200 ease-in-out;
+        @apply flex items-center gap-3 px-3 py-2 text-[13px] font-medium text-text-muted rounded-[5px] transition-colors duration-200 ease-in-out cursor-pointer;
     }
 
     .sidebar-link.active {
-        @apply bg-ems-primary text-white;
-        box-shadow: 4px 4px 0px 0px #000000;
+        @apply bg-navy-50 text-navy-900 font-semibold;
     }
 
-    .sidebar-link:hover {
-        /* @apply bg-background-light; */
-        box-shadow: 4px 4px 0px 0px #000000;
-        transform: translate(-5px, -1px);
+    .sidebar-link:hover:not(.active) {
+        @apply bg-surface-1 text-navy-900;
     }
 
     /* Sidebar section title */
     .sidebar-section-title {
-        @apply px-1 pt-5 pb-2 text-xs font-black uppercase tracking-[0.2em] text-slate-500;
+        @apply px-3 pt-5 pb-2 text-[11px] font-medium uppercase tracking-[0.08em] text-text-muted;
     }
 }

--- a/src/resources/views/auth/login.blade.php
+++ b/src/resources/views/auth/login.blade.php
@@ -4,129 +4,129 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="csrf-token" content="{{ csrf_token() }}">
-    <title>Đăng nhập - EMS</title>
+    <title>Đăng nhập - EduPortal</title>
     @vite(['resources/css/app.css', 'resources/js/app.js'])
 </head>
-<body class="bg-background-light font-display text-slate-900 min-h-screen flex flex-col">
-<header class="w-full bg-white border-b-[3px] border-black px-6 md:px-20 py-4 flex items-center justify-between sticky top-0 z-50">
+<body class="bg-surface-0 font-sans text-navy-900 min-h-screen flex flex-col">
+<header class="w-full bg-white border-b-[0.5px] border-border-clean px-6 md:px-20 py-4 flex items-center justify-between sticky top-0 z-50">
     <div class="flex items-center gap-3">
-        <div class="bg-ems-primary brutal-border p-1 flex items-center justify-center">
-            <span class="material-symbols-outlined text-white text-3xl">database</span>
-        </div>
-        <h1 class="text-2xl font-extrabold tracking-tighter italic">EMS</h1>
+        <div class="w-2.5 h-2.5 rounded-full bg-blue-400"></div>
+        <h1 class="text-[17px] font-semibold tracking-wider uppercase">EduPortal</h1>
     </div>
-    <a href="{{ route('landing') }}" class="text-lg font-bold border-b-[4px] border-black hover:bg-ems-primary/10 px-2 py-1 transition-colors">
+    <a href="{{ route('landing') }}" class="text-[13px] font-medium text-text-muted hover:text-navy-900 transition-colors">
         Về trang chủ
     </a>
 </header>
 
 <main class="flex-grow flex items-center justify-center p-6 md:p-12">
-    <div class="max-w-5xl w-full bg-white brutal-border shadow-brutal-lg flex flex-col md:flex-row overflow-hidden">
-        <div class="md:w-1/2 bg-ems-primary/10 border-b-[3px] md:border-b-0 md:border-r-[3px] border-black p-12 flex flex-col items-center justify-center relative overflow-hidden">
+    <div class="max-w-4xl w-full bg-white border-[0.5px] border-border-clean rounded-[10px] shadow-sm flex flex-col md:flex-row overflow-hidden">
+        <!-- Left Side: Brand -->
+        <div class="md:w-[45%] bg-navy-900 p-12 flex flex-col items-center justify-center relative overflow-hidden">
+            <!-- Decorative circle -->
+            <div class="absolute -top-24 -right-24 w-64 h-64 bg-navy-700/50 rounded-full blur-3xl"></div>
+            <div class="absolute -bottom-24 -left-24 w-64 h-64 bg-blue-600/20 rounded-full blur-3xl"></div>
+
             <div class="relative z-10 text-center">
-                <div class="mb-8 flex justify-center gap-4">
-                    <div class="w-24 h-24 bg-ems-primary brutal-border flex items-center justify-center transform -rotate-6 shadow-brutal">
-                        <span class="material-symbols-outlined text-white text-5xl">school</span>
-                    </div>
-                    <div class="w-24 h-24 bg-white brutal-border flex items-center justify-center transform rotate-12 shadow-brutal">
-                        <span class="material-symbols-outlined text-ems-primary text-5xl">calendar_month</span>
+                <div class="mb-6 flex justify-center">
+                    <div class="w-20 h-20 bg-white/10 rounded-full flex items-center justify-center backdrop-blur-md border-[0.5px] border-white/20">
+                        <span class="material-symbols-outlined text-white text-4xl">school</span>
                     </div>
                 </div>
-                <h2 class="text-3xl font-black text-ems-primary leading-none uppercase mb-2">Hệ thống</h2>
-                <p class="text-xl font-bold bg-black text-white px-3 py-1 inline-block">Quản lý Khảo thí</p>
+                <h2 class="text-[24px] font-semibold text-white leading-tight mb-2">Hệ thống Quản lý</h2>
+                <p class="text-[15px] text-blue-200">Giảng dạy & Khảo thí</p>
             </div>
         </div>
 
-        <div class="md:w-1/2 p-8 md:p-12 flex flex-col justify-center">
-            <div class="mb-8">
-                <h3 class="text-4xl font-black uppercase tracking-tight mb-2">Đăng nhập</h3>
-                <div class="h-2 w-20 bg-ems-primary mb-4"></div>
-                <p class="text-slate-600 font-medium">Giảng viên đăng nhập bằng email và mật khẩu. Sinh viên đăng nhập bằng Google bên dưới.</p>
+        <!-- Right Side: Login -->
+        <div class="md:w-[55%] p-8 md:p-12 flex flex-col justify-center bg-white">
+            <div class="mb-8 text-center md:text-left">
+                <h3 class="text-[22px] font-bold text-navy-900 mb-2">Đăng nhập</h3>
+                <p class="text-[13px] text-text-muted">Vui lòng đăng nhập để truy cập hệ thống theo đúng vai trò của bạn.</p>
             </div>
 
             @if (session('warning'))
-                <div class="mb-4 p-3 bg-yellow-100 brutal-border text-sm font-semibold text-yellow-900">
+                <div class="mb-4 p-3 bg-amber-50 border-[0.5px] border-amber-200 rounded-[6px] text-[13px] font-medium text-amber-700">
                     {{ session('warning') }}
                 </div>
             @endif
 
             @if (session('error'))
-                <div class="mb-4 p-3 bg-red-100 brutal-border text-sm font-semibold text-red-800">
+                <div class="mb-4 p-3 bg-red-50 border-[0.5px] border-red-200 rounded-[6px] text-[13px] font-medium text-red-700">
                     {{ session('error') }}
                 </div>
             @endif
 
             @if ($errors->has('google_auth'))
-                <div class="mb-4 p-3 bg-red-100 brutal-border text-sm font-semibold text-red-800">
+                <div class="mb-4 p-3 bg-red-50 border-[0.5px] border-red-200 rounded-[6px] text-[13px] font-medium text-red-700">
                     {{ $errors->first('google_auth') }}
                 </div>
             @endif
 
-            <form method="POST" action="{{ route('login') }}" class="space-y-5">
+            <form method="POST" action="{{ route('login') }}" class="space-y-4">
                 @csrf
 
                 <div>
-                    <label for="email" class="block text-sm font-black uppercase mb-2 tracking-wide">Email giảng viên</label>
-                    <input id="email" name="email" type="email" value="{{ old('email') }}" required autofocus
-                        class="w-full h-14 px-4 bg-white brutal-border font-bold text-lg placeholder:text-slate-400 focus:ring-0"
-                        placeholder="lecturer@ems.local">
+                    <label for="email" class="block text-[12px] font-medium text-navy-900 mb-1.5">Email giảng viên</label>
+                    <x-text-input id="email" name="email" type="email" value="{{ old('email') }}" required autofocus placeholder="lecturer@ems.local" />
                     @error('email')
-                        <p class="mt-1 text-xs font-semibold text-red-700">{{ $message }}</p>
+                        <p class="mt-1 text-[11px] font-medium text-red-600">{{ $message }}</p>
                     @enderror
                 </div>
 
                 <div>
-                    <label for="password" class="block text-sm font-black uppercase mb-2 tracking-wide">Mật khẩu</label>
-                    <input id="password" name="password" type="password" required
-                        class="w-full h-14 px-4 bg-white brutal-border font-bold text-lg placeholder:text-slate-400 focus:ring-0"
-                        placeholder="••••••••">
+                    <div class="flex justify-between items-center mb-1.5">
+                        <label for="password" class="block text-[12px] font-medium text-navy-900">Mật khẩu</label>
+                        <a href="#" class="text-[11px] text-blue-400 hover:text-navy-600 transition-colors">Quên mật khẩu?</a>
+                    </div>
+                    <x-text-input id="password" name="password" type="password" required placeholder="••••••••" />
                     @error('password')
-                        <p class="mt-1 text-xs font-semibold text-red-700">{{ $message }}</p>
+                        <p class="mt-1 text-[11px] font-medium text-red-600">{{ $message }}</p>
                     @enderror
                 </div>
 
-                <div class="flex items-center gap-2">
-                    <input type="checkbox" id="remember" name="remember" class="rounded border-black text-ems-primary focus:ring-0">
-                    <label for="remember" class="text-sm font-semibold">Ghi nhớ đăng nhập</label>
+                <div class="flex items-center gap-2 py-2">
+                    <input type="checkbox" id="remember" name="remember" class="rounded-[4px] border-[1.5px] border-border-clean text-navy-600 focus:ring-navy-50 w-4 h-4">
+                    <label for="remember" class="text-[12px] font-medium text-navy-900">Ghi nhớ đăng nhập</label>
                 </div>
 
-                <button type="submit"
-                    class="w-full h-14 bg-ems-primary text-white brutal-border shadow-brutal font-black uppercase tracking-widest hover:translate-x-[2px] hover:translate-y-[2px] hover:shadow-none transition-all">
+                <x-button type="submit" variant="primary" class="w-full">
                     Đăng nhập
-                </button>
+                </x-button>
             </form>
 
-            <div class="my-6 flex items-center gap-3">
-                <div class="h-[2px] flex-1 bg-black"></div>
-                <span class="text-xs font-black uppercase tracking-widest">Hoặc</span>
-                <div class="h-[2px] flex-1 bg-black"></div>
+            <div class="my-6 relative">
+                <div class="absolute inset-0 flex items-center">
+                    <div class="w-full border-t-[0.5px] border-border-clean"></div>
+                </div>
+                <div class="relative flex justify-center text-[11px]">
+                    <span class="bg-white px-3 text-text-muted font-medium uppercase tracking-wider">Hoặc</span>
+                </div>
             </div>
 
-            <div class="bg-blue-50 brutal-border p-4 mb-2">
-                <p class="text-xs font-black uppercase tracking-wider text-blue-700 mb-3">Dành cho Sinh viên</p>
-                <a href="{{ route('google.redirect') }}"
-                    class="w-full h-14 bg-white brutal-border shadow-brutal font-black uppercase tracking-wider flex items-center justify-center gap-2 hover:translate-x-[2px] hover:translate-y-[2px] hover:shadow-none transition-all">
-                    <span class="material-symbols-outlined">account_circle</span>
+            <div class="bg-surface-0 border-[0.5px] border-border-clean rounded-[8px] p-4 text-center">
+                <p class="text-[12px] font-medium text-text-muted mb-3">Dành cho Sinh viên</p>
+                <a href="{{ route('google.redirect') }}" class="w-full flex items-center justify-center gap-2 bg-white border-[1.5px] border-border-clean hover:bg-surface-1 text-navy-900 font-medium text-[13px] py-2 px-4 rounded-[6px] transition-colors">
+                    <svg class="w-4 h-4" viewBox="0 0 24 24">
+                        <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4"/>
+                        <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/>
+                        <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05"/>
+                        <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/>
+                        <path d="M1 1h22v22H1z" fill="none"/>
+                    </svg>
                     Đăng nhập với Google
                 </a>
-            </div>
-
-            <div class="mt-8 pt-6 border-t-2 border-dashed border-slate-300">
-                <p class="text-sm font-bold text-slate-600 italic">
-                    Quên mật khẩu giảng viên? Liên hệ quản trị viên để được cấp lại mật khẩu tạm.
-                </p>
             </div>
         </div>
     </div>
 </main>
 
-<footer class="w-full bg-white border-t-[3px] border-black px-6 md:px-20 py-6">
+<footer class="w-full bg-white border-t-[0.5px] border-border-clean px-6 md:px-20 py-6 mt-auto">
     <div class="flex flex-col md:flex-row justify-between items-center gap-4">
-        <p class="text-sm font-black uppercase tracking-widest">© {{ date('Y') }} EMS - EXAM MANAGEMENT SYSTEM</p>
+        <p class="text-[12px] font-medium text-text-muted tracking-wider">© {{ date('Y') }} EduPortal</p>
         <div class="flex gap-6">
-            <a class="text-sm font-bold hover:underline" href="#">Điều khoản</a>
-            <a class="text-sm font-bold hover:underline" href="#">Bảo mật</a>
-            <a class="text-sm font-bold hover:underline" href="#">Hỗ trợ kỹ thuật</a>
+            <a class="text-[12px] font-medium text-text-muted hover:text-navy-900 transition-colors" href="#">Điều khoản</a>
+            <a class="text-[12px] font-medium text-text-muted hover:text-navy-900 transition-colors" href="#">Bảo mật</a>
+            <a class="text-[12px] font-medium text-text-muted hover:text-navy-900 transition-colors" href="#">Hỗ trợ</a>
         </div>
     </div>
 </footer>

--- a/src/resources/views/components/badge.blade.php
+++ b/src/resources/views/components/badge.blade.php
@@ -4,14 +4,14 @@
 
 @php
     $types = [
-        'info'    => 'bg-primary-50 text-primary-700 ring-primary-500/20',
-        'success' => 'bg-success-50 text-success-600 ring-success-500/20',
-        'warning' => 'bg-warning-50 text-warning-600 ring-warning-500/20',
-        'danger'  => 'bg-danger-50 text-danger-600 ring-danger-500/20',
-        'neutral' => 'bg-gray-100 text-gray-600 ring-gray-500/20',
+        'info'    => 'bg-navy-50 text-navy-600',
+        'success' => 'bg-teal-50 text-teal-800',
+        'warning' => 'bg-amber-50 text-amber-600',
+        'danger'  => 'bg-red-50 text-red-600',
+        'neutral' => 'bg-surface-1 text-navy-900 border-[0.5px] border-border-clean',
     ];
 @endphp
 
-<span {{ $attributes->merge(['class' => 'inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ring-1 ring-inset ' . ($types[$type] ?? $types['info'])]) }}>
+<span {{ $attributes->merge(['class' => 'inline-flex items-center px-[10px] py-[3px] rounded-full text-[11px] font-medium ' . ($types[$type] ?? $types['info'])]) }}>
     {{ $slot }}
 </span>

--- a/src/resources/views/components/button.blade.php
+++ b/src/resources/views/components/button.blade.php
@@ -6,23 +6,24 @@
 ])
 
 @php
-    $baseClasses = 'inline-flex items-center justify-center gap-2 font-semibold rounded-lg transition ease-in-out duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed';
+    $baseClasses = 'inline-flex items-center justify-center gap-1.5 font-medium transition-opacity duration-150 hover:opacity-85 focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed';
 
     $variants = [
-        'primary'   => 'bg-primary-500 text-white border border-transparent shadow-sm hover:bg-primary-600 active:bg-primary-700 focus:ring-primary-500',
-        'secondary' => 'bg-white text-gray-700 border border-border shadow-sm hover:bg-surface-hover hover:border-border-dark focus:ring-primary-500',
-        'danger'    => 'bg-danger-500 text-white border border-transparent shadow-sm hover:bg-danger-600 active:bg-danger-600 focus:ring-danger-500',
-        'success'   => 'bg-success-500 text-white border border-transparent shadow-sm hover:bg-success-600 active:bg-success-600 focus:ring-success-500',
-        'warning'   => 'bg-warning-500 text-white border border-transparent shadow-sm hover:bg-warning-600 active:bg-warning-600 focus:ring-warning-500',
-        'ghost'     => 'bg-transparent text-gray-600 border border-transparent hover:bg-surface-hover hover:text-gray-800 focus:ring-primary-500',
-        'outline'   => 'bg-transparent text-primary-500 border border-primary-500 hover:bg-primary-50 focus:ring-primary-500',
+        'primary'   => 'bg-navy-900 text-white',
+        'secondary' => 'bg-navy-50 text-navy-900',
+        'outline'   => 'bg-transparent text-navy-900 border-[1.5px] border-navy-900',
+        'ghost'     => 'bg-transparent text-navy-900 border-[1.5px] border-border-clean',
+        'danger'    => 'bg-red-50 text-red-600',
+        'success'   => 'bg-teal-50 text-teal-800',
+        'warning'   => 'bg-amber-50 text-amber-600',
+        'icon'      => 'bg-navy-50 text-navy-900',
     ];
 
     $sizes = [
-        'xs'  => $iconOnly ? 'p-1.5'    : 'px-3 py-1.5 text-xs',
-        'sm'  => $iconOnly ? 'p-2'      : 'px-4 py-2 text-sm',
-        'md'  => $iconOnly ? 'p-2.5'    : 'px-5 py-2.5 text-sm',
-        'lg'  => $iconOnly ? 'p-3'      : 'px-6 py-3 text-base',
+        'xs'  => $iconOnly ? 'p-1.5 rounded-[5px]' : 'px-3 py-1.5 text-[11px] rounded-[5px]',
+        'sm'  => $iconOnly ? 'p-2 rounded-[5px]'   : 'px-3 py-1.5 text-[11px] rounded-[5px]',
+        'md'  => $iconOnly ? 'p-2 rounded-[6px]'   : 'px-[18px] py-2 text-[13px] rounded-[6px]',
+        'lg'  => $iconOnly ? 'p-2.5 rounded-[8px]' : 'px-6 py-[11px] text-[15px] rounded-[8px]',
     ];
 
     $classes = $baseClasses . ' ' . ($variants[$variant] ?? $variants['primary']) . ' ' . ($sizes[$size] ?? $sizes['md']);

--- a/src/resources/views/components/card.blade.php
+++ b/src/resources/views/components/card.blade.php
@@ -1,15 +1,24 @@
 @props([
     'padding' => true,
     'hoverable' => false,
+    'variant' => 'default', // default, accent, featured
 ])
 
+@php
+    $variants = [
+        'default'  => 'bg-white border-[0.5px] border-border-clean rounded-[10px]',
+        'accent'   => 'bg-white border-[0.5px] border-border-clean border-t-[3px] border-t-navy-900 rounded-[10px]',
+        'featured' => 'bg-surface-1 border-[0.5px] border-blue-200 rounded-[10px]',
+    ];
+@endphp
+
 <div {{ $attributes->merge([
-    'class' => 'bg-white rounded-card shadow-card border border-border/60'
-        . ($padding ? ' p-6' : '')
-        . ($hoverable ? ' hover:shadow-card-hover transition-shadow duration-200' : '')
+    'class' => $variants[$variant]
+        . ($padding ? ' p-4' : '')
+        . ($hoverable ? ' transition-shadow duration-200 hover:shadow-card' : '')
 ]) }}>
     @isset($header)
-        <div class="flex items-center justify-between mb-4 {{ $padding ? '' : 'px-6 pt-6' }}">
+        <div class="flex items-center justify-between mb-4 {{ $padding ? '' : 'px-4 pt-4' }}">
             <div>
                 {{ $header }}
             </div>
@@ -21,12 +30,12 @@
         </div>
     @endisset
 
-    <div class="{{ !$padding && isset($header) ? 'px-6 pb-6' : '' }}">
+    <div class="{{ !$padding && isset($header) ? 'px-4 pb-4' : '' }}">
         {{ $slot }}
     </div>
 
     @isset($footer)
-        <div class="border-t border-border mt-4 pt-4 {{ $padding ? '' : 'px-6 pb-6' }}">
+        <div class="border-t-[0.5px] border-border-clean mt-4 pt-4 {{ $padding ? '' : 'px-4 pb-4' }}">
             {{ $footer }}
         </div>
     @endisset

--- a/src/resources/views/components/text-input.blade.php
+++ b/src/resources/views/components/text-input.blade.php
@@ -1,3 +1,3 @@
 @props(['disabled' => false])
 
-<input @disabled($disabled) {{ $attributes->merge(['class' => 'w-full border-border bg-white text-gray-800 placeholder-gray-400 focus:border-primary-500 focus:ring-primary-500 rounded-lg shadow-sm text-sm py-2.5 px-4 disabled:bg-surface-hover disabled:cursor-not-allowed transition duration-150']) }}>
+<input @disabled($disabled) {{ $attributes->merge(['class' => 'w-full border-[1.5px] border-border-clean bg-white text-navy-900 placeholder-text-muted focus:border-navy-600 focus:ring-[3px] focus:ring-navy-50 rounded-[6px] shadow-none text-[13px] py-2 px-3 disabled:bg-surface-1 disabled:cursor-not-allowed transition duration-150 outline-none font-sans']) }}>

--- a/src/resources/views/layouts/app.blade.php
+++ b/src/resources/views/layouts/app.blade.php
@@ -17,7 +17,7 @@
 
     @stack('styles')
 </head>
-<body class="font-sans antialiased bg-background-light text-gray-900">
+<body class="font-sans antialiased bg-surface-0 text-navy-900">
 
     <div class="flex h-screen overflow-hidden" x-data="{ sidebarOpen: false, searchQuery: '' }">
 
@@ -35,20 +35,14 @@
         </div>
 
         <!-- Sidebar -->
-        <aside class="fixed inset-y-0 left-0 z-50 w-64 bg-background-light border-r-[4px] border-black transform transition-transform duration-300 ease-in-out -translate-x-full lg:translate-x-0 lg:static lg:z-auto flex flex-col"
+        <aside class="fixed inset-y-0 left-0 z-50 w-64 bg-white border-r-[0.5px] border-border-clean transform transition-transform duration-300 ease-in-out -translate-x-full lg:translate-x-0 lg:static lg:z-auto flex flex-col"
                :class="sidebarOpen ? 'translate-x-0' : ''">
 
             <!-- Logo -->
-            <div class="flex items-center gap-3 px-5 h-16 border-b-[4px] border-black flex-shrink-0 bg-white">
-                <div class="flex items-center justify-center w-10 h-10 bg-ems-primary brutal-border">
-                    <svg class="w-6 h-6 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                              d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"/>
-                    </svg>
-                </div>
+            <div class="flex items-center gap-3 px-5 h-[52px] border-b-[0.5px] border-border-clean flex-shrink-0 bg-white">
+                <div class="w-2 h-2 rounded-full bg-blue-400"></div>
                 <div>
-                    <div class="font-black text-slate-900 text-base leading-tight uppercase">EMS</div>
-                    <div class="text-slate-500 text-xs font-bold uppercase tracking-wide">Quản ly Thi trac nghiem</div>
+                    <div class="font-semibold text-navy-900 text-[15px] leading-tight uppercase tracking-wider">EduPortal</div>
                 </div>
             </div>
 
@@ -91,15 +85,15 @@
 
             <!-- Help/Support Card -->
             <div class="flex-shrink-0 px-4 pb-4">
-                <div class="bg-white brutal-border p-4 text-center brutal-shadow">
-                    <div class="w-10 h-10 bg-background-light brutal-border flex items-center justify-center mx-auto mb-2">
-                        <svg class="w-5 h-5 text-slate-700" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <div class="bg-surface-1 border-[0.5px] border-border-clean rounded-[10px] p-4 text-center">
+                    <div class="w-8 h-8 bg-blue-50 rounded-full flex items-center justify-center mx-auto mb-2 text-navy-600">
+                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
                         </svg>
                     </div>
-                    <p class="text-slate-900 text-sm font-black uppercase mb-1">Can ho tro?</p>
-                    <p class="text-slate-500 text-xs font-semibold mb-3">Lien he phong dao tao neu ban gap su co.</p>
-                    <button class="w-full bg-ems-primary text-white text-xs font-black uppercase py-2 px-3 brutal-border brutal-btn">
+                    <p class="text-navy-900 text-[12px] font-semibold mb-1">Cần hỗ trợ?</p>
+                    <p class="text-text-muted text-[11px] mb-3 leading-relaxed">Liên hệ hệ thống nếu bạn gặp sự cố.</p>
+                    <button class="w-full bg-navy-50 text-navy-900 text-[11px] font-medium py-1.5 px-3 rounded-[5px] transition-opacity hover:opacity-80">
                         Gửi yêu cầu
                     </button>
                 </div>
@@ -110,19 +104,19 @@
         <div class="flex flex-col flex-1 overflow-hidden">
 
             <!-- Top Navbar -->
-            <header class="sticky top-0 z-30 h-16 bg-background-light border-b-[4px] border-black">
+            <header class="sticky top-0 z-30 h-[52px] bg-navy-900 text-white">
                 <div class="flex items-center justify-between h-full px-4 sm:px-6">
 
                     <!-- Left: Hamburger + Page title -->
                     <div class="flex items-center gap-4">
-                        <button class="lg:hidden p-2 brutal-border bg-white text-gray-700 hover:bg-background-light transition-colors"
+                        <button class="lg:hidden p-1.5 rounded-[5px] bg-navy-700 text-blue-200 hover:bg-navy-600 transition-colors"
                                 x-on:click="sidebarOpen = !sidebarOpen">
-                            <svg class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/>
                             </svg>
                         </button>
 
-                        <h1 class="text-lg font-black uppercase tracking-wide text-gray-900 leading-tight">
+                        <h1 class="text-[15px] font-semibold text-white">
                             @yield('page-title', 'Dashboard')
                         </h1>
                     </div>
@@ -131,14 +125,14 @@
                     <div class="hidden md:flex flex-1 max-w-md mx-8">
                         <div class="relative w-full">
                             <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                                <svg class="h-5 w-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <svg class="h-4 w-4 text-blue-200" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/>
                                 </svg>
                             </div>
                             <input type="search"
                                    x-model="searchQuery"
-                                   placeholder="Tìm kiếm khóa học..."
-                                   class="block w-full pl-10 pr-4 py-2 bg-white border-[2px] border-black text-sm font-semibold text-gray-700 placeholder-gray-400 focus:bg-white focus:ring-0 transition-colors">
+                                   placeholder="Tìm kiếm..."
+                                   class="block w-full pl-9 pr-3 py-1.5 bg-navy-700 border-none rounded-[5px] text-[13px] text-white placeholder-blue-200 focus:bg-white focus:text-navy-900 focus:ring-0 transition-colors outline-none">
                         </div>
                     </div>
 
@@ -147,7 +141,7 @@
 
                         <!-- Notifications -->
                         @role('student')
-                        <a href="{{ route('student.notifications.index') }}" class="relative p-2 brutal-border bg-white text-gray-700 hover:bg-background-light transition-colors block" title="Thông báo">
+                        <a href="{{ route('student.notifications.index') }}" class="relative p-1.5 rounded-[5px] text-blue-200 hover:text-white transition-colors block" title="Thông báo">
                             <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                                     d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
@@ -155,11 +149,11 @@
                             {{-- Unread badge --}}
                             @php $unreadCount = auth()->user() ? \App\Models\Notification::where('user_id', auth()->id())->whereNull('read_at')->count() : 0; @endphp
                             @if($unreadCount > 0)
-                                <span class="absolute bottom-1 right-1 w-2.5 h-2.5 bg-red-600 rounded-full border-2 border-white" title="Có thông báo mới"></span>
+                                <span class="absolute top-1 right-1 w-2 h-2 bg-red-600 rounded-full" title="Có thông báo mới"></span>
                             @endif
                         </a>
                         @else
-                        <button class="relative p-2 brutal-border bg-white text-gray-700 hover:bg-background-light transition-colors" title="Thông báo">
+                        <button class="relative p-1.5 rounded-[5px] text-blue-200 hover:text-white transition-colors" title="Thông báo">
                             <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                                     d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
@@ -167,29 +161,25 @@
                             {{-- Unread badge --}}
                             @php $unreadCount = auth()->user() ? \App\Models\Notification::where('user_id', auth()->id())->whereNull('read_at')->count() : 0; @endphp
                             @if($unreadCount > 0)
-                                <span class="absolute bottom-1 right-1 w-2.5 h-2.5 bg-red-600 rounded-full border-2 border-white" title="Có thông báo mới"></span>
+                                <span class="absolute top-1 right-1 w-2 h-2 bg-red-600 rounded-full" title="Có thông báo mới"></span>
                             @endif
                         </button>
                         @endrole
 
-                        <!-- Divider -->
-                        <div class="hidden sm:block w-px h-8 bg-black"></div>
-
                         <!-- User Dropdown -->
                         <div class="relative" x-data="{ open: false }">
-                                <button class="flex items-center gap-3 p-1.5 brutal-border bg-white hover:bg-background-light transition-colors"
-                                    x-on:click="open = !open">
-                                <div class="hidden sm:block text-right">
-                                    <p class="text-sm font-semibold text-gray-800">{{ auth()->user()->name }}</p>
-                                    <p class="text-xs text-gray-500">{{ auth()->user()->primary_role ?? 'Người dùng' }}</p>
+                            <button class="flex items-center gap-2" x-on:click="open = !open">
+                                <div class="bg-white/10 rounded-[5px] px-2.5 py-1 hidden sm:flex items-center gap-1.5">
+                                    <div class="w-1.5 h-1.5 rounded-full bg-teal-300"></div>
+                                    <span class="text-blue-200 text-[11px] font-medium">{{ auth()->user()->primary_role ?? 'SV' }}</span>
                                 </div>
-                                <div class="w-9 h-9 rounded-full bg-ems-primary flex items-center justify-center text-white font-semibold text-sm border-2 border-black">
-                                    {{ strtoupper(substr(auth()->user()->name ?? 'U', 0, 1)) }}
+                                <div class="w-[30px] h-[30px] rounded-full bg-navy-700 flex items-center justify-center text-blue-200 font-semibold text-[11px] border-[1.5px] border-blue-400">
+                                    {{ strtoupper(substr(auth()->user()->name ?? 'U', 0, 2)) }}
                                 </div>
                             </button>
 
                             <!-- Dropdown menu -->
-                               <div class="absolute right-0 mt-2 w-56 bg-white brutal-border brutal-shadow py-1 z-50"
+                               <div class="absolute right-0 mt-2 w-56 bg-white border-[0.5px] border-border-clean rounded-[10px] py-1 shadow-card z-50 overflow-hidden"
                                  x-show="open"
                                  x-on:click.outside="open = false"
                                  x-transition:enter="transition ease-out duration-100"
@@ -199,18 +189,22 @@
                                  x-transition:leave-start="opacity-100 scale-100"
                                  x-transition:leave-end="opacity-0 scale-95"
                                  style="display:none">
+                                <div class="px-4 py-3 border-b-[0.5px] border-border-clean bg-surface-0">
+                                    <p class="text-[13px] font-semibold text-navy-900 leading-none mb-1">{{ auth()->user()->name }}</p>
+                                    <p class="text-[11px] text-text-muted leading-none">{{ auth()->user()->email }}</p>
+                                </div>
                                 <a href="{{ route('profile.edit') }}"
-                                   class="flex items-center px-4 py-2.5 text-sm font-bold text-gray-700 hover:bg-background-light border-b border-black/20">
-                                    <svg class="w-4 h-4 mr-2.5 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                   class="flex items-center px-4 py-2 text-[12px] font-medium text-navy-900 hover:bg-surface-1">
+                                    <svg class="w-4 h-4 mr-2.5 text-text-muted" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"/>
                                     </svg>
                                     Hồ sơ cá nhân
                                 </a>
-                                <div class="border-t border-black my-1"></div>
+                                <div class="border-t-[0.5px] border-border-clean my-1"></div>
                                 <form method="POST" action="{{ route('logout') }}">
                                     @csrf
                                     <button type="submit"
-                                            class="flex items-center w-full px-4 py-2.5 text-sm font-black text-danger-500 hover:bg-danger-50">
+                                            class="flex items-center w-full px-4 py-2 text-[12px] font-semibold text-red-600 hover:bg-red-50">
                                         <svg class="w-4 h-4 mr-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                                                 d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />

--- a/src/resources/views/lecturer/classes/create.blade.php
+++ b/src/resources/views/lecturer/classes/create.blade.php
@@ -6,69 +6,64 @@
 
         <div>
             <a href="{{ route('lecturer.classes.index') }}"
-               class="inline-flex items-center gap-1 text-sm font-bold text-slate-500 hover:text-ems-primary mb-4">
-                ← Quay lại danh sách lớp
+               class="inline-flex items-center gap-1.5 text-[13px] font-medium text-text-muted hover:text-navy-900 mb-4 transition-colors">
+                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"/></svg>
+                Quay lại danh sách lớp
             </a>
-            <h2 class="text-2xl font-black uppercase">Tạo lớp học phần mới</h2>
-            <p class="text-sm text-slate-500 font-semibold mt-1">
+            <h2 class="text-[24px] font-bold text-navy-900 leading-tight">Tạo lớp học phần mới</h2>
+            <p class="text-[13px] font-medium text-text-muted mt-1">
                 Sau khi tạo, mã tham gia sẽ được tự động sinh. Chia sẻ mã này cho sinh viên để họ tham gia.
             </p>
         </div>
 
         @if(session('error'))
-            <div class="p-4 bg-red-100 brutal-border font-semibold text-red-800 text-sm">{{ session('error') }}</div>
+            <div class="p-4 bg-red-50 border-[0.5px] border-red-200 rounded-[6px] font-medium text-red-800 text-[13px]">{{ session('error') }}</div>
         @endif
 
-        <form method="POST" action="{{ route('lecturer.classes.store') }}" class="bg-white brutal-border brutal-shadow p-6 space-y-5">
-            @csrf
+        <x-card padding="true">
+            <form method="POST" action="{{ route('lecturer.classes.store') }}" class="space-y-5">
+                @csrf
 
-            <div>
-                <label class="block text-sm font-black uppercase mb-2 tracking-wide" for="name">
-                    Tên lớp học phần <span class="text-red-500">*</span>
-                </label>
-                <input id="name" name="name" type="text" value="{{ old('name') }}" required
-                       placeholder="VD: Lập trình Java — Nhóm 1"
-                       class="w-full h-12 px-4 brutal-border bg-white font-semibold focus:ring-0 @error('name') border-red-500 @enderror">
-                @error('name')
-                    <p class="mt-1 text-xs text-red-600 font-semibold">{{ $message }}</p>
-                @enderror
-            </div>
+                <div>
+                    <label class="block text-[12px] font-medium text-navy-900 mb-1.5" for="name">
+                        Tên lớp học phần <span class="text-red-500">*</span>
+                    </label>
+                    <x-text-input id="name" name="name" type="text" value="{{ old('name') }}" required placeholder="VD: Lập trình Java — Nhóm 1" class="{{ $errors->has('name') ? 'border-red-400 focus:border-red-500 focus:ring-red-100/50' : '' }}" />
+                    @error('name')
+                        <p class="mt-1.5 text-[11px] font-medium text-red-600">{{ $message }}</p>
+                    @enderror
+                </div>
 
-            <div>
-                <label class="block text-sm font-black uppercase mb-2 tracking-wide" for="code">
-                    Mã lớp (nội bộ) <span class="text-red-500">*</span>
-                </label>
-                <input id="code" name="code" type="text" value="{{ old('code') }}" required
-                       placeholder="VD: CS101-01-HK1-2526"
-                       class="w-full h-12 px-4 brutal-border bg-white font-semibold uppercase tracking-widest focus:ring-0 @error('code') border-red-500 @enderror">
-                <p class="mt-1 text-xs text-slate-500 font-semibold">Mã duy nhất, dùng để phân biệt lớp trong hệ thống.</p>
-                @error('code')
-                    <p class="mt-1 text-xs text-red-600 font-semibold">{{ $message }}</p>
-                @enderror
-            </div>
+                <div>
+                    <label class="block text-[12px] font-medium text-navy-900 mb-1.5" for="code">
+                        Mã lớp (nội bộ) <span class="text-red-500">*</span>
+                    </label>
+                    <x-text-input id="code" name="code" type="text" value="{{ old('code') }}" required placeholder="VD: CS101-01-HK1-2526" class="uppercase {{ $errors->has('code') ? 'border-red-400 focus:border-red-500 focus:ring-red-100/50' : '' }}" />
+                    <p class="mt-1.5 text-[11px] font-medium text-text-muted">Mã duy nhất, dùng để phân biệt lớp trong hệ thống.</p>
+                    @error('code')
+                        <p class="mt-1 text-[11px] font-medium text-red-600">{{ $message }}</p>
+                    @enderror
+                </div>
 
-            <div>
-                <label class="block text-sm font-black uppercase mb-2 tracking-wide" for="max_students">
-                    Sĩ số tối đa
-                </label>
-                <input id="max_students" name="max_students" type="number" value="{{ old('max_students', 100) }}"
-                       min="1" max="500"
-                       class="w-full h-12 px-4 brutal-border bg-white font-semibold focus:ring-0">
-                @error('max_students')
-                    <p class="mt-1 text-xs text-red-600 font-semibold">{{ $message }}</p>
-                @enderror
-            </div>
+                <div>
+                    <label class="block text-[12px] font-medium text-navy-900 mb-1.5" for="max_students">
+                        Sĩ số tối đa
+                    </label>
+                    <x-text-input id="max_students" name="max_students" type="number" value="{{ old('max_students', 100) }}" min="1" max="500" class="{{ $errors->has('max_students') ? 'border-red-400 focus:border-red-500 focus:ring-red-100/50' : '' }}" />
+                    @error('max_students')
+                        <p class="mt-1 text-[11px] font-medium text-red-600">{{ $message }}</p>
+                    @enderror
+                </div>
 
-            <div class="pt-2 flex gap-3">
-                <button type="submit"
-                        class="h-12 px-8 bg-ems-primary text-white brutal-border brutal-shadow font-black uppercase tracking-widest brutal-btn">
-                    Tạo lớp
-                </button>
-                <a href="{{ route('lecturer.classes.index') }}"
-                   class="h-12 px-6 flex items-center bg-white brutal-border font-black uppercase tracking-wide brutal-btn text-sm">
-                    Huỷ
-                </a>
-            </div>
-        </form>
+                <div class="pt-4 flex gap-3">
+                    <x-button type="submit" variant="primary">
+                        Tạo lớp
+                    </x-button>
+                    <x-button variant="outline" href="{{ route('lecturer.classes.index') }}">
+                        Huỷ
+                    </x-button>
+                </div>
+            </form>
+        </x-card>
     </div>
 </x-app-layout>

--- a/src/resources/views/lecturer/classes/edit.blade.php
+++ b/src/resources/views/lecturer/classes/edit.blade.php
@@ -6,74 +6,69 @@
 
         <div>
             <a href="{{ route('lecturer.classes.show', $section) }}"
-               class="inline-flex items-center gap-1 text-sm font-bold text-slate-500 hover:text-ems-primary mb-4">
-                ← Quay lại chi tiết lớp
+               class="inline-flex items-center gap-1.5 text-[13px] font-medium text-text-muted hover:text-navy-900 mb-4 transition-colors">
+                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"/></svg>
+                Quay lại chi tiết lớp
             </a>
-            <h2 class="text-2xl font-black uppercase">Chỉnh sửa: {{ $section->name ?? $section->code }}</h2>
+            <h2 class="text-[24px] font-bold text-navy-900 leading-tight">Chỉnh sửa: {{ $section->name ?? $section->code }}</h2>
         </div>
 
         @if(session('error'))
-            <div class="p-4 bg-red-100 brutal-border font-semibold text-red-800 text-sm">{{ session('error') }}</div>
+            <div class="p-4 bg-red-50 border-[0.5px] border-red-200 rounded-[6px] font-medium text-red-800 text-[13px]">{{ session('error') }}</div>
         @endif
 
-        <form method="POST" action="{{ route('lecturer.classes.update', $section) }}"
-              class="bg-white brutal-border brutal-shadow p-6 space-y-5">
-            @csrf
-            @method('PUT')
+        <x-card padding="true">
+            <form method="POST" action="{{ route('lecturer.classes.update', $section) }}" class="space-y-5">
+                @csrf
+                @method('PUT')
 
-            <div>
-                <label class="block text-sm font-black uppercase mb-2 tracking-wide" for="name">
-                    Tên lớp học phần <span class="text-red-500">*</span>
-                </label>
-                <input id="name" name="name" type="text" value="{{ old('name', $section->name) }}" required
-                       class="w-full h-12 px-4 brutal-border bg-white font-semibold focus:ring-0 @error('name') border-red-500 @enderror">
-                @error('name')
-                    <p class="mt-1 text-xs text-red-600 font-semibold">{{ $message }}</p>
-                @enderror
-            </div>
+                <div>
+                    <label class="block text-[12px] font-medium text-navy-900 mb-1.5" for="name">
+                        Tên lớp học phần <span class="text-red-500">*</span>
+                    </label>
+                    <x-text-input id="name" name="name" type="text" value="{{ old('name', $section->name) }}" required class="{{ $errors->has('name') ? 'border-red-400 focus:border-red-500 focus:ring-red-100/50' : '' }}" />
+                    @error('name')
+                        <p class="mt-1.5 text-[11px] font-medium text-red-600">{{ $message }}</p>
+                    @enderror
+                </div>
 
-            <div>
-                <label class="block text-sm font-black uppercase mb-2 tracking-wide" for="code">
-                    Mã lớp (nội bộ) <span class="text-red-500">*</span>
-                </label>
-                <input id="code" name="code" type="text" value="{{ old('code', $section->code) }}" required
-                       class="w-full h-12 px-4 brutal-border bg-white font-semibold uppercase tracking-widest focus:ring-0 @error('code') border-red-500 @enderror">
-                @error('code')
-                    <p class="mt-1 text-xs text-red-600 font-semibold">{{ $message }}</p>
-                @enderror
-            </div>
+                <div>
+                    <label class="block text-[12px] font-medium text-navy-900 mb-1.5" for="code">
+                        Mã lớp (nội bộ) <span class="text-red-500">*</span>
+                    </label>
+                    <x-text-input id="code" name="code" type="text" value="{{ old('code', $section->code) }}" required class="uppercase {{ $errors->has('code') ? 'border-red-400 focus:border-red-500 focus:ring-red-100/50' : '' }}" />
+                    @error('code')
+                        <p class="mt-1.5 text-[11px] font-medium text-red-600">{{ $message }}</p>
+                    @enderror
+                </div>
 
-            <div>
-                <label class="block text-sm font-black uppercase mb-2 tracking-wide" for="max_students">Sĩ số tối đa</label>
-                <input id="max_students" name="max_students" type="number"
-                       value="{{ old('max_students', $section->max_students) }}"
-                       min="1" max="500"
-                       class="w-full h-12 px-4 brutal-border bg-white font-semibold focus:ring-0">
-                @error('max_students')
-                    <p class="mt-1 text-xs text-red-600 font-semibold">{{ $message }}</p>
-                @enderror
-            </div>
+                <div>
+                    <label class="block text-[12px] font-medium text-navy-900 mb-1.5" for="max_students">Sĩ số tối đa</label>
+                    <x-text-input id="max_students" name="max_students" type="number" value="{{ old('max_students', $section->max_students) }}" min="1" max="500" class="{{ $errors->has('max_students') ? 'border-red-400 focus:border-red-500 focus:ring-red-100/50' : '' }}" />
+                    @error('max_students')
+                        <p class="mt-1.5 text-[11px] font-medium text-red-600">{{ $message }}</p>
+                    @enderror
+                </div>
 
-            <div>
-                <label class="block text-sm font-black uppercase mb-2 tracking-wide" for="status">Trạng thái</label>
-                <select id="status" name="status"
-                        class="w-full h-12 px-4 brutal-border bg-white font-semibold focus:ring-0">
-                    <option value="active"    @selected(old('status', $section->status) === 'active')>Đang mở</option>
-                    <option value="archived"  @selected(old('status', $section->status) === 'archived')>Lưu trữ</option>
-                    <option value="cancelled" @selected(old('status', $section->status) === 'cancelled')>Đã huỷ</option>
-                </select>
-            </div>
+                <div>
+                    <label class="block text-[12px] font-medium text-navy-900 mb-1.5" for="status">Trạng thái</label>
+                    <select id="status" name="status"
+                            class="w-full px-4 py-2 border-[1.5px] border-border-clean rounded-[6px] text-navy-900 font-medium text-[14px] bg-white hover:border-blue-400 focus:border-blue-400 focus:ring-4 focus:ring-blue-100/50 transition-all outline-none">
+                        <option value="active"    @selected(old('status', $section->status) === 'active')>Đang mở</option>
+                        <option value="archived"  @selected(old('status', $section->status) === 'archived')>Lưu trữ</option>
+                        <option value="cancelled" @selected(old('status', $section->status) === 'cancelled')>Đã huỷ</option>
+                    </select>
+                </div>
 
-            <div class="pt-2 flex gap-3">
-                <button type="submit"
-                        class="h-12 px-8 bg-ems-primary text-white brutal-border brutal-shadow font-black uppercase tracking-widest brutal-btn">
-                    Lưu thay đổi
-                </button>
-                <a href="{{ route('lecturer.classes.show', $section) }}"
-                   class="h-12 px-6 flex items-center bg-white brutal-border font-black uppercase tracking-wide brutal-btn text-sm">
-                    Huỷ
-                </a>
-            </div>
-        </form>
+                <div class="pt-4 flex gap-3">
+                    <x-button type="submit" variant="primary">
+                        Lưu thay đổi
+                    </x-button>
+                    <x-button variant="outline" href="{{ route('lecturer.classes.show', $section) }}">
+                        Huỷ
+                    </x-button>
+                </div>
+            </form>
+        </x-card>
     </div>
 </x-app-layout>

--- a/src/resources/views/lecturer/classes/index.blade.php
+++ b/src/resources/views/lecturer/classes/index.blade.php
@@ -7,42 +7,40 @@
         {{-- Header --}}
         <div class="flex items-center justify-between">
             <div>
-                <h2 class="text-2xl font-black uppercase">Lớp học phần của tôi</h2>
-                <p class="text-sm font-semibold text-slate-500 mt-1">Quản lý và tạo các lớp học phần bạn phụ trách.</p>
+                <h2 class="text-[24px] font-bold text-navy-900 leading-tight">Lớp học phần của tôi</h2>
+                <p class="text-[13px] font-medium text-text-muted mt-1">Quản lý và tạo các lớp học phần bạn phụ trách.</p>
             </div>
-            <a href="{{ route('lecturer.classes.create') }}"
-               class="h-10 px-5 flex items-center gap-2 bg-ems-primary text-white brutal-border brutal-shadow font-black uppercase tracking-wide brutal-btn text-sm">
+            <x-button variant="primary" href="{{ route('lecturer.classes.create') }}" class="flex items-center gap-2">
                 <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M12 4v16m8-8H4"/>
                 </svg>
                 Tạo lớp mới
-            </a>
+            </x-button>
         </div>
 
         @if(session('success'))
-            <div class="p-4 bg-green-100 brutal-border font-semibold text-green-800 text-sm">
+            <div class="p-4 bg-teal-50 border-[0.5px] border-teal-200 rounded-[6px] font-medium text-teal-800 text-[13px]">
                 {{ session('success') }}
             </div>
         @endif
         @if(session('error'))
-            <div class="p-4 bg-red-100 brutal-border font-semibold text-red-800 text-sm">
+            <div class="p-4 bg-red-50 border-[0.5px] border-red-200 rounded-[6px] font-medium text-red-800 text-[13px]">
                 {{ session('error') }}
             </div>
         @endif
 
         {{-- Class Grid --}}
         @if($sections->isEmpty())
-            <div class="text-center py-20 brutal-border bg-white">
-                <svg class="mx-auto w-14 h-14 text-slate-300 mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <div class="text-center py-20 bg-surface-0 border-[0.5px] border-border-clean border-dashed rounded-[10px]">
+                <svg class="mx-auto w-12 h-12 text-blue-200 mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
                           d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"/>
                 </svg>
-                <p class="font-black uppercase text-slate-400 text-lg">Chưa có lớp học phần nào</p>
-                <p class="text-slate-400 text-sm mt-2 mb-6">Tạo lớp học phần đầu tiên và chia sẻ mã mời cho sinh viên.</p>
-                <a href="{{ route('lecturer.classes.create') }}"
-                   class="inline-flex items-center gap-2 h-10 px-6 bg-ems-primary text-white brutal-border brutal-shadow font-black uppercase tracking-wide brutal-btn text-sm">
+                <p class="font-semibold text-navy-900 text-[16px]">Chưa có lớp học phần nào</p>
+                <p class="text-[13px] text-text-muted mt-2 mb-6">Tạo lớp học phần đầu tiên và chia sẻ mã mời cho sinh viên.</p>
+                <x-button variant="primary" href="{{ route('lecturer.classes.create') }}">
                     Tạo lớp ngay
-                </a>
+                </x-button>
             </div>
         @else
             <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">
@@ -50,22 +48,21 @@
                     @php
                         $searchableText = strtolower(($section->name ?? '') . ' ' . $section->code);
                     @endphp
-                    <div class="bg-white brutal-border brutal-shadow flex flex-col"
-                         x-show="searchQuery === '' || '{{ $searchableText }}'.includes(searchQuery.toLowerCase())">
+                    <x-card class="flex flex-col h-full overflow-hidden" x-show="searchQuery === '' || '{{ $searchableText }}'.includes(searchQuery.toLowerCase())">
                         {{-- Card Top --}}
-                        <div class="p-5 border-b-4 border-black
-                            @if($section->status === 'active') bg-ems-primary/10
-                            @elseif($section->status === 'archived') bg-slate-100
+                        <div class="px-5 py-4 border-b-[0.5px] border-border-clean
+                            @if($section->status === 'active') bg-surface-1
+                            @elseif($section->status === 'archived') bg-slate-50
                             @else bg-red-50 @endif">
                             <div class="flex items-start justify-between gap-3">
                                 <div>
-                                    <p class="font-black text-xs uppercase tracking-widest text-slate-500">{{ $section->code }}</p>
-                                    <h3 class="font-black text-lg leading-tight mt-1">{{ $section->name ?? $section->code }}</h3>
+                                    <p class="font-semibold text-[11px] uppercase tracking-wider text-text-muted">{{ $section->code }}</p>
+                                    <h3 class="font-bold text-[16px] text-navy-900 leading-tight mt-1">{{ $section->name ?? $section->code }}</h3>
                                 </div>
-                                <span class="uppercase text-xs font-black px-2 py-1 brutal-border shrink-0
-                                    @if($section->status === 'active') bg-green-200 text-green-800
-                                    @elseif($section->status === 'archived') bg-slate-200 text-slate-600
-                                    @else bg-red-200 text-red-700 @endif">
+                                <span class="uppercase text-[10px] font-bold px-2 py-1 rounded-[4px] shrink-0
+                                    @if($section->status === 'active') bg-teal-50 text-teal-800 border-[0.5px] border-teal-200
+                                    @elseif($section->status === 'archived') bg-slate-100 text-slate-600 border-[0.5px] border-slate-200
+                                    @else bg-red-50 text-red-700 border-[0.5px] border-red-200 @endif">
                                     {{ match($section->status) {
                                         'active'   => 'Đang mở',
                                         'archived' => 'Đã lưu trữ',
@@ -76,35 +73,33 @@
                         </div>
 
                         {{-- Card Body --}}
-                        <div class="p-5 flex-1 space-y-3">
-                            <div class="flex items-center justify-between text-sm">
-                                <span class="font-semibold text-slate-500">Sinh viên</span>
-                                <span class="font-black">{{ $section->students_count ?? 0 }} / {{ $section->max_students }}</span>
+                        <div class="p-5 flex-1 space-y-4">
+                            <div class="flex items-center justify-between text-[13px]">
+                                <span class="font-medium text-text-muted">Sinh viên</span>
+                                <span class="font-bold text-navy-900">{{ $section->students_count ?? 0 }} <span class="text-text-muted font-medium">/ {{ $section->max_students }}</span></span>
                             </div>
-                            <div class="flex items-center justify-between text-sm">
-                                <span class="font-semibold text-slate-500">Mã tham gia</span>
-                                <span class="font-black font-mono bg-slate-100 brutal-border px-2 py-0.5 text-xs tracking-widest uppercase">
+                            <div class="flex items-center justify-between text-[13px]">
+                                <span class="font-medium text-text-muted">Mã tham gia</span>
+                                <span class="font-mono bg-surface-0 border-[0.5px] border-border-clean px-2 py-0.5 text-[12px] rounded-[4px] font-bold text-navy-600 uppercase">
                                     {{ $section->invite_code ?? '—' }}
                                 </span>
                             </div>
                         </div>
 
                         {{-- Card Footer --}}
-                        <div class="px-5 pb-5 flex gap-2">
-                            <a href="{{ route('lecturer.classes.show', $section) }}"
-                               class="flex-1 h-9 flex items-center justify-center bg-ems-primary text-white brutal-border font-black text-xs uppercase tracking-wide brutal-btn">
+                        <div class="px-5 pb-5 pt-2 flex gap-3">
+                            <x-button variant="primary" href="{{ route('lecturer.classes.show', $section) }}" class="flex-1 text-center justify-center">
                                 Xem chi tiết
-                            </a>
-                            <a href="{{ route('lecturer.classes.edit', $section) }}"
-                               class="h-9 px-3 flex items-center justify-center bg-white brutal-border font-black text-xs uppercase brutal-btn">
+                            </x-button>
+                            <x-button variant="outline" href="{{ route('lecturer.classes.edit', $section) }}" class="px-3">
                                 Sửa
-                            </a>
+                            </x-button>
                         </div>
-                    </div>
+                    </x-card>
                 @endforeach
             </div>
 
-            <div>{{ $sections->links() }}</div>
+            <div class="mt-6">{{ $sections->links() }}</div>
         @endif
     </div>
 </x-app-layout>

--- a/src/resources/views/lecturer/classes/show.blade.php
+++ b/src/resources/views/lecturer/classes/show.blade.php
@@ -6,42 +6,44 @@
 
         <div class="flex items-center justify-between">
             <a href="{{ route('lecturer.classes.index') }}"
-                class="inline-flex items-center gap-1 text-sm font-bold text-slate-500 hover:text-ems-primary">
-                ← Danh sách lớp
+                class="inline-flex items-center gap-1.5 text-[13px] font-medium text-text-muted hover:text-navy-900 transition-colors">
+                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"/></svg>
+                Danh sách lớp
             </a>
             <div class="flex items-center gap-3">
-                <button onclick="document.getElementById('create-notification-modal').classList.remove('hidden')"
-                    class="h-9 px-4 flex items-center bg-ems-primary text-white brutal-border font-black text-xs uppercase brutal-btn brutal-shadow">
+                <x-button variant="outline" onclick="document.getElementById('create-notification-modal').classList.remove('hidden')">
                     Tạo thông báo
-                </button>
-                <a href="{{ route('lecturer.course-sections.exams.create', $section) }}"
-                    class="h-9 px-4 flex items-center bg-ems-primary text-white brutal-border font-black text-xs uppercase brutal-btn brutal-shadow">
+                </x-button>
+                <x-button variant="secondary" href="{{ route('lecturer.course-sections.exams.create', $section) }}">
                     Tạo bài kiểm tra
-                </a>
-                <a href="{{ route('lecturer.classes.edit', $section) }}"
-                    class="h-9 px-4 flex items-center bg-white brutal-border font-black text-xs uppercase brutal-btn brutal-shadow">
+                </x-button>
+                <x-button variant="primary" href="{{ route('lecturer.classes.edit', $section) }}">
                     Chỉnh sửa
-                </a>
+                </x-button>
             </div>
         </div>
 
         @if(session('success'))
-        <div class="p-4 bg-green-100 brutal-border font-semibold text-green-800 text-sm">{{ session('success') }}</div>
+            <div class="p-4 bg-teal-50 border-[0.5px] border-teal-200 rounded-[6px] font-medium text-teal-800 text-[13px] hover:bg-teal-100 transition-colors cursor-pointer">
+                {{ session('success') }}
+            </div>
         @endif
         @if(session('error'))
-        <div class="p-4 bg-red-100 brutal-border font-semibold text-red-800 text-sm">{{ session('error') }}</div>
+            <div class="p-4 bg-red-50 border-[0.5px] border-red-200 rounded-[6px] font-medium text-red-800 text-[13px]">
+                {{ session('error') }}
+            </div>
         @endif
 
         {{-- Class Info Card --}}
-        <div class="bg-white brutal-border brutal-shadow p-6">
-            <div class="flex flex-col md:flex-row md:items-start md:justify-between gap-4">
+        <x-card padding="true">
+            <div class="flex flex-col md:flex-row md:items-start md:justify-between gap-6">
                 <div>
-                    <p class="text-xs font-black uppercase tracking-widest text-slate-400">{{ $section->code }}</p>
-                    <h2 class="text-3xl font-black mt-1">{{ $section->name ?? $section->code }}</h2>
-                    <span class="inline-block mt-2 uppercase text-xs font-black px-2 py-1 brutal-border
-                        @if($section->status === 'active') bg-green-200 text-green-800
-                        @elseif($section->status === 'archived') bg-slate-200 text-slate-600
-                        @else bg-red-200 text-red-700 @endif">
+                    <p class="text-[12px] font-semibold uppercase tracking-wider text-text-muted mb-1">{{ $section->code }}</p>
+                    <h2 class="text-[26px] font-bold text-navy-900 leading-tight mb-3">{{ $section->name ?? $section->code }}</h2>
+                    <span class="inline-block uppercase text-[11px] font-bold px-2.5 py-1 rounded-[4px]
+                                    @if($section->status === 'active') bg-teal-50 text-teal-800 border-[0.5px] border-teal-200
+                                    @elseif($section->status === 'archived') bg-slate-100 text-slate-600 border-[0.5px] border-slate-200
+                                    @else bg-red-50 text-red-700 border-[0.5px] border-red-200 @endif">
                         {{ match($section->status) {
                             'active'   => 'Đang mở',
                             'archived' => 'Đã lưu trữ',
@@ -51,87 +53,87 @@
                 </div>
 
                 {{-- Invite Code Box --}}
-                <div class="brutal-border bg-ems-primary/5 p-5 text-center min-w-[200px]">
-                    <p class="text-xs font-black uppercase tracking-widest text-slate-500 mb-2">Mã tham gia lớp</p>
-                    <p class="text-4xl font-black tracking-[0.3em] uppercase font-mono">
+                <div class="border-[0.5px] border-border-clean bg-surface-0 rounded-[8px] p-5 text-center min-w-[220px]">
+                    <p class="text-[11px] font-semibold uppercase tracking-wider text-text-muted mb-2">Mã tham gia lớp</p>
+                    <p class="text-[32px] font-bold text-navy-900 tracking-[0.2em] uppercase font-mono mb-1">
                         {{ $section->invite_code ?? '——' }}
                     </p>
-                    <p class="text-xs text-slate-400 font-semibold mt-2">Chia sẻ mã này cho sinh viên</p>
+                    <p class="text-[12px] text-text-muted font-medium">Chia sẻ mã này cho sinh viên</p>
 
-                    <form method="POST" action="{{ route('lecturer.classes.regenerate-code', $section) }}" class="mt-3">
+                    <form method="POST" action="{{ route('lecturer.classes.regenerate-code', $section) }}" class="mt-4">
                         @csrf
                         <button type="submit"
                             onclick="return confirm('Tạo mã mới? Mã cũ sẽ không còn hoạt động.')"
-                            class="text-xs font-black uppercase text-ems-primary hover:underline">
+                            class="text-[12px] font-semibold text-blue-500 hover:text-blue-700 transition-colors">
                             Tạo mã mới
                         </button>
                     </form>
                 </div>
             </div>
 
-            <div class="mt-6 grid grid-cols-2 md:grid-cols-3 gap-4 border-t-4 border-black pt-6">
+            <div class="mt-8 grid grid-cols-2 md:grid-cols-3 gap-6 border-t-[0.5px] border-border-clean pt-6">
                 <div>
-                    <p class="text-xs font-black uppercase text-slate-400">Sĩ số tối đa</p>
-                    <p class="text-xl font-black mt-1">{{ $section->max_students }}</p>
+                    <p class="text-[12px] font-medium text-text-muted mb-1">Sĩ số tối đa</p>
+                    <p class="text-[20px] font-bold text-navy-900 leading-none">{{ $section->max_students }}</p>
                 </div>
                 <div>
-                    <p class="text-xs font-black uppercase text-slate-400">Đang theo học</p>
-                    <p class="text-xl font-black mt-1">{{ $section->students->count() }}</p>
+                    <p class="text-[12px] font-medium text-text-muted mb-1">Đang theo học</p>
+                    <p class="text-[20px] font-bold text-navy-900 leading-none">{{ $section->students->count() }}</p>
                 </div>
                 <div>
-                    <p class="text-xs font-black uppercase text-slate-400">Tạo ngày</p>
-                    <p class="text-xl font-black mt-1">{{ $section->created_at->format('d/m/Y') }}</p>
+                    <p class="text-[12px] font-medium text-text-muted mb-1">Ngày tạo</p>
+                    <p class="text-[20px] font-bold text-navy-900 leading-none">{{ $section->created_at->format('d/m/Y') }}</p>
                 </div>
             </div>
-        </div>
+        </x-card>
 
         {{-- Student List --}}
-        <div class="bg-white brutal-border brutal-shadow p-6">
-            <h3 class="text-xl font-black uppercase mb-4">Danh sách sinh viên ({{ $section->students->count() }})</h3>
+        <x-card padding="true">
+            <h3 class="text-[18px] font-bold text-navy-900 mb-6">Danh sách sinh viên ({{ $section->students->count() }})</h3>
 
             @if($section->students->isEmpty())
-            <div class="text-center py-10">
-                <p class="text-slate-400 font-semibold">Chưa có sinh viên nào tham gia lớp này.</p>
-                <p class="text-slate-400 text-sm mt-1">Chia sẻ mã tham gia cho sinh viên của bạn.</p>
+            <div class="text-center py-12 bg-surface-0 border-[0.5px] border-border-clean border-dashed rounded-[8px]">
+                <p class="text-[13px] font-medium text-text-muted mb-1">Chưa có sinh viên nào tham gia lớp này.</p>
+                <p class="text-[12px] text-text-muted">Chia sẻ mã tham gia phía trên cho sinh viên của bạn.</p>
             </div>
             @else
             <div class="overflow-x-auto">
-                <table class="w-full text-sm">
+                <table class="w-full text-left border-collapse">
                     <thead>
-                        <tr class="border-b-4 border-black">
-                            <th class="text-left py-2 px-3 font-black uppercase text-xs tracking-wide">Họ tên</th>
-                            <th class="text-left py-2 px-3 font-black uppercase text-xs tracking-wide">Email</th>
-                            <th class="text-left py-2 px-3 font-black uppercase text-xs tracking-wide">MSSV</th>
-                            <th class="text-left py-2 px-3 font-black uppercase text-xs tracking-wide">Ngày tham gia</th>
+                        <tr class="border-b-[1.5px] border-border-clean">
+                            <th class="py-3 px-4 text-[12px] font-semibold text-text-muted uppercase tracking-wider">Họ tên</th>
+                            <th class="py-3 px-4 text-[12px] font-semibold text-text-muted uppercase tracking-wider">Email</th>
+                            <th class="py-3 px-4 text-[12px] font-semibold text-text-muted uppercase tracking-wider">MSSV</th>
+                            <th class="py-3 px-4 text-[12px] font-semibold text-text-muted uppercase tracking-wider">Ngày tham gia</th>
                         </tr>
                     </thead>
-                    <tbody>
+                    <tbody class="divide-y-[0.5px] divide-border-clean">
                         @foreach($section->students->sortBy('name') as $student)
-                        <tr class="border-b-2 border-dashed border-slate-200 hover:bg-slate-50">
-                            <td class="py-3 px-3 font-semibold">{{ $student->name }}</td>
-                            <td class="py-3 px-3 text-slate-600">{{ $student->email }}</td>
-                            <td class="py-3 px-3 font-mono font-bold">{{ $student->student_code ?? '—' }}</td>
-                            <td class="py-3 px-3 text-slate-500">{{ $student->pivot->enrolled_at ? \Carbon\Carbon::parse($student->pivot->enrolled_at)->format('d/m/Y') : '—' }}</td>
+                        <tr class="hover:bg-surface-0 transition-colors">
+                            <td class="py-4 px-4 text-[14px] font-medium text-navy-900">{{ $student->name }}</td>
+                            <td class="py-4 px-4 text-[13px] text-text-muted">{{ $student->email }}</td>
+                            <td class="py-4 px-4 text-[13px] font-mono font-medium text-navy-600">{{ $student->student_code ?? '—' }}</td>
+                            <td class="py-4 px-4 text-[13px] text-text-muted">{{ $student->pivot->enrolled_at ? \Carbon\Carbon::parse($student->pivot->enrolled_at)->format('d/m/Y') : '—' }}</td>
                         </tr>
                         @endforeach
                     </tbody>
                 </table>
             </div>
             @endif
-        </div>
+        </x-card>
 
         {{-- Danger zone --}}
         @if($section->students->isEmpty())
-        <div class="bg-white brutal-border border-red-400 p-6">
-            <h3 class="text-lg font-black text-red-600 uppercase mb-2">Xoá lớp học phần</h3>
-            <p class="text-sm text-slate-600 font-semibold mb-4">Hành động này không thể hoàn tác. Lớp sẽ bị xoá vĩnh viễn.</p>
+        <div class="bg-red-50 border-[0.5px] border-red-200 rounded-[10px] p-6">
+            <h3 class="text-[16px] font-bold text-red-700 mb-1">Xoá lớp học phần</h3>
+            <p class="text-[13px] text-red-600/80 font-medium mb-4">Hành động này không thể hoàn tác. Lớp sẽ bị xoá vĩnh viễn khỏi hệ thống.</p>
             <form method="POST" action="{{ route('lecturer.classes.destroy', $section) }}">
                 @csrf
                 @method('DELETE')
                 <button type="submit"
                     onclick="return confirm('Bạn có chắc muốn xoá lớp này không?')"
-                    class="h-10 px-6 bg-red-500 text-white brutal-border font-black text-sm uppercase brutal-btn">
-                    Xoá lớp
+                    class="h-9 px-5 bg-red-600 text-white font-medium text-[13px] rounded-[6px] hover:bg-red-700 transition-colors">
+                    Xoá lớp vĩnh viễn
                 </button>
             </form>
         </div>
@@ -140,26 +142,30 @@
     </div>
 
     {{-- Notification Modal --}}
-    <div id="create-notification-modal" class="hidden fixed inset-0 bg-black/60 z-50 flex items-center justify-center p-4">
-        <div class="bg-white brutal-border brutal-shadow-lg w-full max-w-lg p-8">
+    <div id="create-notification-modal" class="hidden fixed inset-0 bg-navy-900/40 backdrop-blur-sm z-50 flex items-center justify-center p-4">
+        <div class="bg-white border-[0.5px] border-border-clean rounded-[10px] shadow-sm w-full max-w-lg p-6 md:p-8">
             <div class="flex items-center justify-between mb-6">
-                <h3 class="text-2xl font-black uppercase">Tạo thông báo</h3>
-                <button onclick="document.getElementById('create-notification-modal').classList.add('hidden')" class="font-black text-2xl leading-none hover:text-ems-primary">&times;</button>
+                <h3 class="text-[20px] font-bold text-navy-900">Tạo thông báo</h3>
+                <button onclick="document.getElementById('create-notification-modal').classList.add('hidden')" class="text-text-muted hover:text-navy-900 transition-colors">
+                    <svg class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/></svg>
+                </button>
             </div>
 
-            <form method="POST" action="{{ route('lecturer.classes.notifications.store', $section) }}" class="space-y-4">
+            <form method="POST" action="{{ route('lecturer.classes.notifications.store', $section) }}" class="space-y-5">
                 @csrf
                 <div>
-                    <label class="block text-sm font-black uppercase mb-2">Tiêu đề</label>
-                    <input name="title" type="text" required placeholder="Nhập tiêu đề thông báo" class="w-full h-12 px-4 bg-white brutal-border font-bold focus:ring-0">
+                    <label class="block text-[12px] font-medium text-navy-900 mb-1.5">Tiêu đề</label>
+                    <x-text-input name="title" type="text" required placeholder="Nhập tiêu đề thông báo mới" />
                 </div>
                 <div>
-                    <label class="block text-sm font-black uppercase mb-2">Nội dung</label>
-                    <textarea name="message" required rows="4" placeholder="Nội dung thông báo..." class="w-full p-4 bg-white brutal-border font-semibold focus:ring-0"></textarea>
+                    <label class="block text-[12px] font-medium text-navy-900 mb-1.5">Nội dung chi tiết</label>
+                    <textarea name="message" required rows="5" placeholder="Viết nội dung thông báo gửi đến sinh viên..." class="w-full p-4 bg-white border-[1.5px] border-border-clean rounded-[6px] text-[14px] text-navy-900 placeholder:text-slate-400 focus:border-blue-400 focus:ring-4 focus:ring-blue-100/50 transition-all outline-none resize-y"></textarea>
                 </div>
-                <button type="submit" class="w-full h-12 bg-ems-primary text-white brutal-border font-black uppercase tracking-widest hover:translate-x-[2px] hover:translate-y-[2px] hover:shadow-none transition-all shadow-brutal">
-                    Gửi thông báo
-                </button>
+                <div class="pt-2 flex justify-end">
+                    <x-button type="submit" variant="primary">
+                        Đăng thông báo
+                    </x-button>
+                </div>
             </form>
         </div>
     </div>

--- a/src/resources/views/lecturer/dashboard.blade.php
+++ b/src/resources/views/lecturer/dashboard.blade.php
@@ -13,92 +13,96 @@
         <div class="space-y-6">
 
             @if(session('success'))
-                <div class="p-4 bg-green-100 brutal-border font-semibold text-green-800 text-sm">{{ session('success') }}</div>
+                <div class="p-4 bg-teal-50 border-[0.5px] border-teal-200 rounded-[6px] font-medium text-teal-800 text-[13px]">{{ session('success') }}</div>
             @endif
 
-            <section class="bg-background-light brutal-border shadow-brutal-lg p-6 md:p-8">
+            <x-card padding="true" variant="featured">
                 <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-6">
                     <div>
-                        <p class="text-xs font-black uppercase tracking-[0.2em] text-slate-600">Lecturer Cockpit</p>
-                        <h2 class="mt-2 text-3xl md:text-4xl font-black uppercase tracking-tight">Xin chào, {{ $lecturer->name }}</h2>
-                        <p class="mt-3 text-sm md:text-base font-semibold text-slate-700">
+                        <h2 class="text-[22px] md:text-[28px] font-bold text-navy-900 leading-tight">Xin chào, {{ auth()->user()->name }}!</h2>
+                        <p class="mt-2 text-[13px] text-text-muted">
                             @if($lecturer->lecturer_code)
-                                Mã GV: <span class="font-black">{{ $lecturer->lecturer_code }}</span>
+                                Mã GV: <span class="font-semibold text-navy-900">{{ $lecturer->lecturer_code }}</span>
                             @endif
                             @if($lecturer->department)
-                                — {{ $lecturer->department }}
+                                — Lĩnh vực: <span class="font-semibold text-navy-900">{{ $lecturer->department }}</span>
                             @endif
                         </p>
                     </div>
 
                     <div class="flex items-center gap-3">
-                        <a href="{{ route('lecturer.classes.create') }}"
-                           class="h-12 px-5 flex items-center justify-center bg-ems-primary text-white brutal-border brutal-shadow font-black uppercase tracking-wide brutal-btn">
+                        <x-button variant="outline" href="{{ route('lecturer.classes.create') }}">
                             + Tạo lớp mới
-                        </a>
-                        <a href="{{ route('lecturer.classes.index') }}"
-                           class="h-12 px-5 flex items-center justify-center bg-white brutal-border brutal-shadow font-black uppercase tracking-wide brutal-btn">
+                        </x-button>
+                        <x-button variant="secondary" href="{{ route('lecturer.classes.index') }}">
                             Quản lý lớp
-                        </a>
+                        </x-button>
                     </div>
                 </div>
-            </section>
+            </x-card>
 
-            <section class="grid grid-cols-1 md:grid-cols-3 gap-4">
-                <article class="bg-white brutal-border brutal-shadow p-5">
-                    <p class="text-xs font-black uppercase tracking-[0.2em] text-slate-500">Lớp học phần</p>
-                    <p class="mt-3 text-4xl font-black leading-none">{{ $activeCount }}</p>
-                    <p class="mt-2 text-sm font-semibold text-slate-600">Số lớp đang mở</p>
-                </article>
+            <section class="grid grid-cols-1 md:grid-cols-3 gap-6">
+                <x-card padding="true">
+                    <p class="text-[12px] font-medium text-text-muted mb-1">Số lớp đang mở</p>
+                    <div class="flex items-baseline gap-2">
+                        <p class="text-[28px] font-bold text-navy-900 leading-none">{{ $activeCount }}</p>
+                        <span class="text-[12px] text-text-muted">lớp</span>
+                    </div>
+                </x-card>
 
-                <article class="bg-white brutal-border brutal-shadow p-5">
-                    <p class="text-xs font-black uppercase tracking-[0.2em] text-slate-500">Sinh viên</p>
-                    <p class="mt-3 text-4xl font-black leading-none">{{ $studentTotal }}</p>
-                    <p class="mt-2 text-sm font-semibold text-slate-600">Tổng sinh viên đang theo học</p>
-                </article>
+                <x-card padding="true" variant="accent">
+                    <p class="text-[12px] font-medium text-text-muted mb-1">Sinh viên theo học</p>
+                    <div class="flex items-baseline gap-2">
+                        <p class="text-[28px] font-bold text-navy-900 leading-none">{{ $studentTotal }}</p>
+                        <span class="text-[12px] text-text-muted">sinh viên</span>
+                    </div>
+                </x-card>
 
-                <article class="bg-white brutal-border brutal-shadow p-5">
-                    <p class="text-xs font-black uppercase tracking-[0.2em] text-slate-500">Câu hỏi</p>
-                    <p class="mt-3 text-4xl font-black leading-none">{{ $questionCount }}</p>
-                    <p class="mt-2 text-sm font-semibold text-slate-600">Ngân hàng câu hỏi cá nhân</p>
-                </article>
+                <x-card padding="true">
+                    <p class="text-[12px] font-medium text-text-muted mb-1">Ngân hàng câu hỏi</p>
+                    <div class="flex items-baseline gap-2">
+                        <p class="text-[28px] font-bold text-navy-900 leading-none">{{ $questionCount }}</p>
+                        <span class="text-[12px] text-text-muted">câu</span>
+                    </div>
+                </x-card>
             </section>
 
             {{-- My class list preview --}}
-            <section class="bg-white brutal-border brutal-shadow p-6">
-                <div class="flex items-center justify-between mb-4">
-                    <h3 class="text-xl font-black uppercase">Lớp học phần của tôi</h3>
-                    <a href="{{ route('lecturer.classes.index') }}" class="text-sm font-black text-ems-primary hover:underline">Xem tất cả →</a>
-                </div>
+            <x-card padding="true">
+                <x-slot name="header">
+                    <div class="flex items-center justify-between">
+                        <h3 class="text-[17px] font-semibold text-navy-900">Lớp học phần của tôi</h3>
+                        <a href="{{ route('lecturer.classes.index') }}" class="text-[13px] font-medium text-blue-400 hover:text-navy-900 hover:underline">Xem kết quả  →</a>
+                    </div>
+                </x-slot>
 
                 @if($mySections->isEmpty())
-                    <div class="text-center py-8">
-                        <p class="text-slate-400 font-semibold">Chưa có lớp học phần nào.</p>
-                        <a href="{{ route('lecturer.classes.create') }}"
-                           class="mt-3 inline-flex items-center h-10 px-5 bg-ems-primary text-white brutal-border font-black text-sm uppercase brutal-btn brutal-shadow">
+                    <div class="text-center py-10 bg-surface-0 border-[0.5px] border-border-clean border-dashed rounded-[8px]">
+                        <p class="text-[13px] text-text-muted font-medium mb-4">Chưa có lớp học phần nào.</p>
+                        <x-button variant="primary" href="{{ route('lecturer.classes.create') }}">
                             Tạo lớp ngay
-                        </a>
+                        </x-button>
                     </div>
                 @else
-                    <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+                    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
                         @foreach($mySections->take(6) as $section)
                             @php
                                 $searchableText = strtolower(($section->name ?? '') . ' ' . $section->code);
                             @endphp
                             <a href="{{ route('lecturer.classes.show', $section) }}"
-                               class="brutal-border p-4 bg-background-light hover:bg-ems-primary/10 transition-colors flex items-start justify-between gap-3"
+                               class="border-[0.5px] border-border-clean bg-surface-0 rounded-[8px] p-4 flex items-start justify-between gap-3 hover:border-blue-200 transition-colors"
                                x-show="searchQuery === '' || '{{ $searchableText }}'.includes(searchQuery.toLowerCase())">
                                 <div>
-                                    <p class="font-black text-sm uppercase">{{ $section->name ?? $section->code }}</p>
-                                    <p class="text-xs text-slate-500 font-semibold mt-0.5">{{ $section->students_count }} sinh viên</p>
+                                    <p class="font-semibold text-[14px] text-navy-900">{{ $section->name ?? $section->code }}</p>
+                                    <p class="text-[12px] text-text-muted font-medium mt-0.5">{{ $section->students_count }} sinh viên</p>
                                 </div>
-                                <span class="font-mono text-xs font-black bg-white brutal-border px-2 py-1 tracking-widest uppercase">
+                                <span class="font-mono text-[11px] font-medium text-navy-600 bg-white border-[0.5px] border-border-clean px-2 py-0.5 rounded-[4px] uppercase">
                                     {{ $section->invite_code ?? '—' }}
                                 </span>
                             </a>
                         @endforeach
                     </div>
                 @endif
-            </section>
+            </x-card>
         </div>
 </x-app-layout>

--- a/src/resources/views/student/dashboard.blade.php
+++ b/src/resources/views/student/dashboard.blade.php
@@ -4,43 +4,40 @@
 
     <div class="space-y-6">
         @if(session('success'))
-        <div class="p-4 bg-green-100 brutal-border font-semibold text-green-800 text-sm">{{ session('success') }}</div>
+        <div class="p-4 bg-teal-50 border-[0.5px] border-teal-200 rounded-[6px] font-medium text-teal-800 text-[13px]">{{ session('success') }}</div>
         @endif
 
         @if(session('error'))
-        <div class="p-4 bg-red-100 brutal-border font-semibold text-red-800 text-sm">{{ session('error') }}</div>
+        <div class="p-4 bg-red-50 border-[0.5px] border-red-200 rounded-[6px] font-medium text-red-800 text-[13px]">{{ session('error') }}</div>
         @endif
 
-        <section class="bg-background-light brutal-border shadow-brutal-lg p-6 md:p-8">
+        <x-card padding="true" variant="featured">
             <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-6">
                 <div>
-                    <p class="text-xs font-black uppercase tracking-[0.2em] text-slate-600">Student Hub</p>
-                    <h2 class="mt-2 text-3xl md:text-4xl font-black uppercase tracking-tight">Xin chào, {{ auth()->user()->name }}</h2>
-                    <p class="mt-3 text-sm md:text-base font-semibold text-slate-700">
+                    <h2 class="text-[22px] md:text-[28px] font-bold text-navy-900 leading-tight">Xin chào, {{ auth()->user()->name }}!</h2>
+                    <p class="mt-2 text-[13px] text-text-muted">
                         @if (auth()->user()->student_code)
-                        MSSV: <span class="font-black">{{ auth()->user()->student_code }}</span>
+                        Mã sinh viên: <span class="font-semibold text-navy-900">{{ auth()->user()->student_code }}</span>
                         @if(auth()->user()->class_name)
-                        - Lớp: <span class="font-black">{{ auth()->user()->class_name }}</span>
+                        — Lớp: <span class="font-semibold text-navy-900">{{ auth()->user()->class_name }}</span>
                         @endif
                         @else
                         Bạn chưa cập nhật thông tin sinh viên.
-                        <a href="{{ route('onboarding.show') }}" class="underline text-ems-primary font-black">Hoàn tất hồ sơ ngay</a>
+                        <a href="{{ route('onboarding.show') }}" class="text-blue-400 font-medium hover:underline">Hoàn tất hồ sơ ngay</a>
                         @endif
                     </p>
                 </div>
 
                 <div class="flex items-center gap-3">
-                    <button onclick="document.getElementById('join-class-modal').classList.remove('hidden')"
-                        class="h-12 px-5 flex items-center justify-center bg-white brutal-border brutal-shadow font-black uppercase tracking-wide brutal-btn">
+                    <x-button variant="outline" onclick="document.getElementById('join-class-modal').classList.remove('hidden')">
                         + Tham gia lớp
-                    </button>
-                    <a href="{{ route('profile.edit') }}"
-                        class="h-12 px-5 flex items-center justify-center bg-white brutal-border brutal-shadow font-black uppercase tracking-wide brutal-btn">
+                    </x-button>
+                    <x-button variant="secondary" href="{{ route('profile.edit') }}">
                         Hồ sơ
-                    </a>
+                    </x-button>
                 </div>
             </div>
-        </section>
+        </x-card>
 
         @php
         // Lấy danh sách lớp học đã tham gia
@@ -54,72 +51,72 @@
         ->get();
         @endphp
 
-        <section class="grid grid-cols-1 md:grid-cols-3 gap-4">
-            <article class="bg-white brutal-border brutal-shadow p-5">
-                <p class="text-xs font-black uppercase tracking-[0.2em] text-slate-500">Học phần đang theo</p>
-                <p class="mt-3 text-4xl font-black leading-none">{{ $enrolledSections->count() }}</p>
-                <p class="mt-2 text-sm font-semibold text-slate-600">Lớp học phần đã tham gia</p>
-            </article>
-            <article class="bg-white brutal-border brutal-shadow p-5">
-                <p class="text-xs font-black uppercase tracking-[0.2em] text-slate-500">Bài thi</p>
-                <p class="mt-3 text-4xl font-black leading-none">{{ $exams->count() }}</p>
-                <p class="mt-2 text-sm font-semibold text-slate-600">Tổng số bài kiểm tra</p>
-            </article>
-            <article class="bg-white brutal-border brutal-shadow p-5">
-                <p class="text-xs font-black uppercase tracking-[0.2em] text-slate-500">Chuyên cần</p>
-                <p class="mt-3 text-4xl font-black leading-none">-%</p>
-                <p class="mt-2 text-sm font-semibold text-slate-600">Tỷ lệ tham gia buổi học</p>
-            </article>
+        <section class="grid grid-cols-1 md:grid-cols-3 gap-6">
+            <x-card padding="true">
+                <p class="text-[12px] font-medium text-text-muted mb-1">Học phần đang theo</p>
+                <div class="flex items-baseline gap-2">
+                    <p class="text-[28px] font-bold text-navy-900 leading-none">{{ $enrolledSections->count() }}</p>
+                    <span class="text-[12px] text-text-muted">lớp</span>
+                </div>
+            </x-card>
+            <x-card padding="true" variant="accent">
+                <p class="text-[12px] font-medium text-text-muted mb-1">Bài thi</p>
+                <div class="flex items-baseline gap-2">
+                    <p class="text-[28px] font-bold text-navy-900 leading-none">{{ $exams->count() }}</p>
+                    <span class="text-[12px] text-text-muted">bài</span>
+                </div>
+            </x-card>
+            <x-card padding="true">
+                <p class="text-[12px] font-medium text-text-muted mb-1">Chuyên cần</p>
+                <div class="flex items-baseline gap-2">
+                    <p class="text-[28px] font-bold text-navy-900 leading-none">-%</p>
+                    <span class="text-[12px] text-text-muted">đã tham gia</span>
+                </div>
+            </x-card>
         </section>
 
-        <section class="bg-white brutal-border brutal-shadow p-6">
-            <div class="flex items-center justify-between mb-4">
-                <h3 class="text-xl font-black uppercase">Bài Kiểm Tra & Kỳ Thi</h3>
-            </div>
+        <x-card padding="true">
+            <x-slot name="header">
+                <h3 class="text-[17px] font-semibold text-navy-900">Bài Kiểm Tra & Kỳ Thi</h3>
+            </x-slot>
 
             @if($exams->isEmpty())
-            <div class="text-center py-10 bg-gray-50 brutal-border border-dashed">
-                <p class="text-slate-500 font-semibold">Chưa có bài kiểm tra nào được giao cho bạn.</p>
+            <div class="text-center py-10 bg-surface-0 border-[0.5px] border-border-clean border-dashed rounded-[8px]">
+                <p class="text-text-muted text-[13px] font-medium">Bạn chưa có bài thi nào.</p>
             </div>
             @else
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
                 @foreach($exams as $exam)
-                <div class="brutal-border p-5 bg-yellow-50 flex flex-col justify-between relative group hover:-translate-y-1 hover:shadow-brutal-lg transition-all">
-                    <div class="absolute -top-3 -right-3 bg-ems-primary text-white text-xs font-black px-3 py-1 brutal-border shadow-brutal rotate-3">
-                        {{ $exam->duration_minutes }} PHÚT
+                <div class="border-[0.5px] border-border-clean p-4 rounded-[8px] bg-white hover:border-blue-200 transition-colors flex flex-col justify-between">
+                    <div class="mb-4">
+                        <div class="flex items-center justify-between mb-2">
+                            <x-badge type="warning">Còn {{ $exam->duration_minutes }} phút</x-badge>
+                            <span class="text-[11px] text-text-muted">{{ $exam->created_at->format('d/m/Y') }}</span>
+                        </div>
+                        <h4 class="font-semibold text-[15px] text-navy-900 leading-snug mb-1">{{ $exam->title }}</h4>
+                        <p class="text-[12px] text-text-muted">{{ $exam->courseSection->name ?? $exam->courseSection->code }}</p>
                     </div>
 
-                    <div class="mb-6 mt-2">
-                        <h4 class="font-black text-xl uppercase leading-tight mb-2">{{ $exam->title }}</h4>
-                        <p class="text-sm font-bold text-slate-600 flex items-center gap-2">
-                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"></path>
-                            </svg>
-                            {{ $exam->courseSection->name ?? $exam->courseSection->code }}
-                        </p>
-                    </div>
-
-                    <a href="{{ route('student.exams.show', $exam->id) }}" class="w-full h-10 flex items-center justify-center bg-black text-white brutal-border font-black text-sm uppercase brutal-btn brutal-shadow group-hover:bg-ems-primary">
+                    <x-button variant="primary" size="sm" class="w-full" href="{{ route('student.exams.show', $exam->id) }}">
                         Vào Phòng Thi
-                    </a>
+                    </x-button>
                 </div>
                 @endforeach
             </div>
             @endif
-        </section>
+        </x-card>
 
-        <section class="bg-white brutal-border brutal-shadow p-6">
-            <div class="flex items-center justify-between mb-4">
-                <h3 class="text-xl font-black uppercase">Lớp học phần của tôi</h3>
-            </div>
+        <x-card padding="true">
+            <x-slot name="header">
+                <h3 class="text-[17px] font-semibold text-navy-900">Lớp học phần của tôi</h3>
+            </x-slot>
 
             @if($enrolledSections->isEmpty())
             <div class="text-center py-10">
-                <p class="text-slate-400 font-semibold">Bạn chưa tham gia lớp nào</p>
-                <button onclick="document.getElementById('join-class-modal').classList.remove('hidden')"
-                    class="mt-4 h-10 px-6 inline-flex items-center bg-ems-primary text-white brutal-border font-black text-sm uppercase brutal-btn brutal-shadow">
+                <p class="text-text-muted text-[13px] mb-4">Bạn chưa tham gia lớp nào.</p>
+                <x-button variant="primary" onclick="document.getElementById('join-class-modal').classList.remove('hidden')">
                     Tham gia lớp ngay
-                </button>
+                </x-button>
             </div>
             @else
             <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -127,19 +124,19 @@
                 @php
                 $searchableText = strtolower(($section->name ?? '') . ' ' . $section->code);
                 @endphp
-                <div class="brutal-border p-4 bg-background-light flex items-center justify-between gap-4"
+                <div class="border-[0.5px] border-border-clean bg-surface-0 rounded-[8px] p-4 flex items-center justify-between gap-4"
                     x-show="searchQuery === '' || '{{ $searchableText }}'.includes(searchQuery.toLowerCase())">
                     <div>
-                        <p class="font-black text-sm uppercase tracking-wide">{{ $section->name ?? $section->code }}</p>
-                        <p class="text-xs font-semibold text-slate-500 mt-0.5">{{ $section->code }}</p>
+                        <p class="font-semibold text-[14px] text-navy-900 leading-tight">{{ $section->name ?? $section->code }}</p>
+                        <p class="text-[12px] text-text-muted mt-1 font-mono">{{ $section->code }}</p>
                         @if($section->lecturer)
-                        <p class="text-xs font-semibold text-slate-400 mt-0.5">GV: {{ $section->lecturer->name }}</p>
+                        <p class="text-[12px] text-text-muted mt-0.5">Giảng viên: {{ $section->lecturer->name }}</p>
                         @endif
                     </div>
-                    <form method="POST" action="{{ route('student.leave-class', $section) }}" onsubmit="return confirm('Roi khoi lop nay?')">
+                    <form method="POST" action="{{ route('student.leave-class', $section) }}" onsubmit="return confirm('Bạn có chắc muốn rời lớp này?')">
                         @csrf
                         @method('DELETE')
-                        <button type="submit" class="text-xs font-black text-red-500 hover:underline uppercase">
+                        <button type="submit" class="text-[12px] font-medium text-red-600 hover:text-red-700 hover:underline">
                             Rời lớp
                         </button>
                     </form>
@@ -147,37 +144,42 @@
                 @endforeach
             </div>
             @endif
-        </section>
+        </x-card>
     </div>
 
-    <div id="join-class-modal" class="hidden fixed inset-0 bg-black/60 z-50 flex items-center justify-center p-4">
-        <div class="bg-white brutal-border brutal-shadow-lg w-full max-w-md p-8">
+    <div id="join-class-modal" class="hidden fixed inset-0 bg-navy-950/60 z-50 flex items-center justify-center p-4 backdrop-blur-sm">
+        <x-card padding="true" class="w-full max-w-md">
             <div class="flex items-center justify-between mb-6">
-                <h3 class="text-2xl font-black uppercase">Tham gia lớp học</h3>
-                <button onclick="document.getElementById('join-class-modal').classList.add('hidden')" class="font-black text-2xl leading-none hover:text-ems-primary">&times;</button>
+                <h3 class="text-[17px] font-semibold text-navy-900">Tham gia lớp học</h3>
+                <button onclick="document.getElementById('join-class-modal').classList.add('hidden')" class="text-text-muted hover:text-navy-900">
+                    <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/></svg>
+                </button>
             </div>
 
             @if(!auth()->user()->student_code)
-            <p class="mb-4 font-semibold text-slate-600">Trước tiên hãy hoàn tất hồ sơ sinh viên (nhập MSSV).</p>
-            <a href="{{ route('onboarding.show') }}" class="w-full block text-center h-12 bg-ems-primary text-white brutal-border font-black uppercase tracking-wider leading-[3rem]">
-                Nhập thông tin sinh viên
-            </a>
+            <div class="bg-amber-50 border-[0.5px] border-amber-600 rounded-[8px] p-4 text-center">
+                <p class="text-[12px] text-amber-600 font-medium mb-3">Trước tiên hãy hoàn tất hồ sơ sinh viên (nhập MSSV).</p>
+                <x-button variant="primary" class="w-full" href="{{ route('onboarding.show') }}">
+                    Nhập thông tin sinh viên
+                </x-button>
+            </div>
             @else
             <form method="POST" action="{{ route('student.join-class') }}" class="space-y-4">
                 @csrf
                 <div>
-                    <label class="block text-sm font-black uppercase mb-2">Mã lớp học</label>
-                    <input name="invite_code" type="text" required placeholder="Nhập mã lớp (VD: ABC123)" class="w-full h-12 px-4 bg-white brutal-border font-bold text-lg focus:ring-0 uppercase tracking-widest">
+                    <label class="block text-[12px] font-medium text-navy-900 mb-1">Mã lớp học</label>
+                    <x-text-input name="invite_code" type="text" required placeholder="VD: ABC123" class="font-mono" />
                     @error('invite_code')
-                    <p class="mt-1 text-xs font-semibold text-red-700">{{ $message }}</p>
+                    <p class="mt-1 text-[11px] font-medium text-red-600">{{ $message }}</p>
                     @enderror
                 </div>
-                <button type="submit" class="w-full h-12 bg-ems-primary text-white brutal-border font-black uppercase tracking-widest hover:translate-x-[2px] hover:translate-y-[2px] hover:shadow-none transition-all shadow-brutal">
-                    Tham gia
-                </button>
+                <div class="flex justify-end gap-2 pt-2">
+                    <x-button variant="ghost" onclick="document.getElementById('join-class-modal').classList.add('hidden')">Hủy bỏ</x-button>
+                    <x-button type="submit" variant="primary">Tham gia</x-button>
+                </div>
             </form>
             @endif
-        </div>
+        </x-card>
     </div>
 
     @if($errors->has('invite_code') || session('error'))

--- a/src/resources/views/student/notifications/index.blade.php
+++ b/src/resources/views/student/notifications/index.blade.php
@@ -11,40 +11,47 @@
     }">
         <div class="space-y-6">
             @if($notifications->isEmpty())
-                <div class="bg-white brutal-border brutal-shadow p-10 text-center">
-                    <p class="text-slate-500 font-bold">Bạn chưa có thông báo nào.</p>
+                <div class="bg-surface-0 border-[0.5px] border-border-clean border-dashed rounded-[10px] p-12 text-center">
+                    <svg class="w-12 h-12 text-blue-200 mx-auto mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
+                    </svg>
+                    <p class="text-[15px] text-navy-900 font-semibold mb-1">Bạn chưa có thông báo nào.</p>
+                    <p class="text-[13px] text-text-muted">Các thông báo từ giảng viên sẽ xuất hiện tại đây.</p>
                 </div>
             @else
-                <div class="bg-white brutal-border brutal-shadow">
-                    @foreach($notifications as $notification)
-                        @php
-                            $data = is_array($notification->data) ? $notification->data : json_decode($notification->data, true);
-                            $className = $data['course_section_name'] ?? 'Hệ thống';
-                        @endphp
-                        <div class="p-5 border-b-2 border-dashed border-slate-300 last:border-b-0 hover:bg-slate-50 flex flex-col md:flex-row md:items-start justify-between gap-4">
-                            <div>
-                                <span class="inline-block px-2 py-1 bg-ems-primary/10 text-ems-primary text-[10px] font-black uppercase brutal-border mb-2 object-left">
-                                    {{ $className }}
-                                </span>
-                                <h3 class="font-black text-lg mb-2 uppercase">{{ $notification->title }}</h3>
-                                <p class="text-slate-600 font-semibold text-sm line-clamp-2 md:max-w-3xl mb-3">{{ $notification->message }}</p>
-                                <p class="text-xs text-slate-400 font-bold">{{ $notification->created_at->format('d/m/Y H:i') }}</p>
+                <x-card class="overflow-hidden">
+                    <div class="divide-y-[0.5px] divide-border-clean">
+                        @foreach($notifications as $notification)
+                            @php
+                                $data = is_array($notification->data) ? $notification->data : json_decode($notification->data, true);
+                                $className = $data['course_section_name'] ?? 'Hệ thống';
+                            @endphp
+                            <div class="p-5 hover:bg-surface-0 transition-colors flex flex-col md:flex-row md:items-start justify-between gap-4">
+                                <div class="flex-1 min-w-0">
+                                    <div class="flex items-center gap-2 mb-2">
+                                        <span class="inline-block px-2 py-0.5 bg-blue-50 text-blue-700 border-[0.5px] border-blue-200 rounded-[4px] text-[10px] font-bold uppercase tracking-wider">
+                                            {{ $className }}
+                                        </span>
+                                        <span class="text-[11px] text-text-muted font-medium">{{ $notification->created_at->format('d/m/Y H:i') }}</span>
+                                    </div>
+                                    <h3 class="font-bold text-[16px] text-navy-900 mb-1 truncate">{{ $notification->title }}</h3>
+                                    <p class="text-text-muted text-[13px] line-clamp-2 md:max-w-3xl pr-4">{{ $notification->message }}</p>
+                                </div>
+                                <div class="shrink-0 mt-2 md:mt-0 self-start">
+                                    <x-button variant="outline" class="!px-3 !py-1.5" x-on:click="
+                                            currentTitle = '{{ addslashes($notification->title) }}';
+                                            currentMessage = '{{ addslashes(str_replace([\"\r\", \"\n\"], [\"\", \"\\n\"], $notification->message)) }}';
+                                            currentDate = '{{ $notification->created_at->format('d/m/Y H:i') }}';
+                                            currentClass = '{{ addslashes($className) }}';
+                                            modalOpen = true;
+                                        ">
+                                        Xem chi tiết
+                                    </x-button>
+                                </div>
                             </div>
-                            <div class="shrink-0 mt-2 md:mt-0">
-                                <button x-on:click="
-                                        currentTitle = '{{ addslashes($notification->title) }}';
-                                        currentMessage = '{{ addslashes(str_replace(["\r", "\n"], ["", "\\n"], $notification->message)) }}';
-                                        currentDate = '{{ $notification->created_at->format('d/m/Y H:i') }}';
-                                        currentClass = '{{ addslashes($className) }}';
-                                        modalOpen = true;
-                                    "
-                                    class="h-9 px-4 bg-white hover:bg-ems-primary hover:text-white text-black brutal-border brutal-btn font-black text-xs uppercase brutal-shadow">
-                                    Chi tiết
-                                </button>
-                            </div>
-                        </div>
-                    @endforeach
-                </div>
+                        @endforeach
+                    </div>
+                </x-card>
 
                 {{-- Pagination --}}
                 <div class="mt-6">
@@ -54,25 +61,27 @@
         </div>
 
         {{-- Detail Modal --}}
-        <div x-show="modalOpen" class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60" style="display: none;"
+        <div x-show="modalOpen" class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-navy-900/40 backdrop-blur-sm" style="display: none;"
              x-transition:enter="transition ease-out duration-200"
              x-transition:enter-start="opacity-0"
              x-transition:enter-end="opacity-100"
              x-transition:leave="transition ease-in duration-150"
              x-transition:leave-start="opacity-100"
              x-transition:leave-end="opacity-0">
-            <div x-on:click.outside="modalOpen = false" class="bg-white brutal-border brutal-shadow-lg w-full max-w-2xl flex flex-col max-h-[90vh]">
-                <div class="p-5 border-b-4 border-black flex items-center justify-between shrink-0 bg-ems-primary/5">
+            <div x-on:click.outside="modalOpen = false" class="bg-white border-[0.5px] border-border-clean rounded-[10px] shadow-sm w-full max-w-2xl flex flex-col max-h-[90vh] overflow-hidden">
+                <div class="p-6 border-b-[0.5px] border-border-clean flex items-start justify-between shrink-0 bg-surface-0">
                     <div>
-                        <span x-text="currentClass" class="text-[10px] font-black text-ems-primary uppercase tracking-widest mb-1 block"></span>
-                        <h3 x-text="currentTitle" class="text-xl font-black uppercase"></h3>
+                        <span x-text="currentClass" class="inline-block px-2 py-0.5 bg-blue-50 text-blue-700 border-[0.5px] border-blue-200 rounded-[4px] text-[10px] font-bold uppercase tracking-wider mb-2"></span>
+                        <h3 x-text="currentTitle" class="text-[18px] font-bold text-navy-900 leading-tight"></h3>
                     </div>
-                    <button x-on:click="modalOpen = false" class="text-3xl font-black leading-none hover:text-ems-primary self-start">&times;</button>
+                    <button x-on:click="modalOpen = false" class="text-text-muted hover:text-navy-900 transition-colors p-1">
+                        <svg class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/></svg>
+                    </button>
                 </div>
-                <div class="p-6 overflow-y-auto whitespace-pre-wrap font-semibold text-slate-700 leading-relaxed text-sm" x-text="currentMessage">
+                <div class="p-6 overflow-y-auto whitespace-pre-wrap text-navy-900 text-[14px] leading-relaxed" x-text="currentMessage">
                 </div>
-                <div class="p-4 border-t-4 border-black text-xs font-bold text-slate-500 text-right shrink-0 bg-slate-50">
-                    Đã gửi lúc: <span x-text="currentDate"></span>
+                <div class="py-3 px-6 border-t-[0.5px] border-border-clean text-[12px] font-medium text-text-muted text-right shrink-0 bg-surface-0">
+                    Đã gửi lúc: <span x-text="currentDate" class="font-semibold text-navy-900"></span>
                 </div>
             </div>
         </div>

--- a/src/tailwind.config.js
+++ b/src/tailwind.config.js
@@ -15,7 +15,7 @@ export default {
     theme: {
         extend: {
             fontFamily: {
-                sans: ['Inter', ...defaultTheme.fontFamily.sans],
+                sans: ['"Be Vietnam Pro"', 'Inter', ...defaultTheme.fontFamily.sans],
                 display: ['Inter', 'sans-serif'],
             },
             colors: {
@@ -78,6 +78,45 @@ export default {
                     500: '#EF4444',
                     600: '#DC2626',
                 },
+                navy: {
+                    50: '#E6F1FB', // Blue 50
+                    200: '#B5D4F4', // Blue 200
+                    400: '#378ADD', // Blue 400
+                    600: '#185FA5', // Navy 600
+                    700: '#2A5298', // Navy 700
+                    900: '#1A3A6B', // Navy 900
+                    950: '#0B2347', // Navy 950
+                },
+                teal: {
+                    50: '#E1F5EE',
+                    200: '#9FE1CB',
+                    300: '#5DCAA5',
+                    500: '#1D9E75',
+                    700: '#0F6E56',
+                    800: '#065F46',
+                },
+                surface: {
+                    DEFAULT: '#FFFFFF',
+                    muted: '#F8FAFC',
+                    hover: '#F1F5F9',
+                    0: '#F8FAFD',
+                    1: '#F4F7FC',
+                    2: '#EBF2FA',
+                },
+                amber: {
+                    50: '#FEF3C7',
+                    400: '#FBBF24',
+                    600: '#D97706',
+                },
+                text: {
+                    muted: '#6B7C99',
+                    primary: '#1A3A6B',
+                },
+                border: {
+                    DEFAULT: '#E2E8F0',
+                    dark: '#CBD5E1',
+                    clean: '#D6E2F0',
+                },
             },
             boxShadow: {
                 'card': '0 1px 3px 0 rgba(0, 0, 0, 0.08), 0 1px 2px -1px rgba(0, 0, 0, 0.04)',
@@ -88,6 +127,10 @@ export default {
             },
             borderRadius: {
                 'card': '0.75rem',
+            },
+            borderWidth: {
+                '0.5': '0.5px',
+                '1.5': '1.5px',
             },
         },
     },


### PR DESCRIPTION
Sửa đổi: Triển khai hệ thống thiết kế mới và làm mới giao diện người dùng trên nhiều khung nhìn và thành phần khác nhau. Phong cách thiết kế mới "Clean Academic"

Về màu sắc: Toàn bộ hệ thống xoay quanh trục Navy #1A3A6B — đây là màu "gương mặt" của thương hiệu, xuất hiện ở navbar, heading, nút primary và mọi điểm nhấn quan trọng. Blue nhạt #E6F1FB làm nền hover/chip. Teal #1D9E75 chỉ xuất hiện khi cần nói "tốt/hoàn thành". Màu đỏ #DC2626 dành riêng cho cảnh báo — không dùng trang trí.
Về hình dạng: Bo góc tối đa 10px cho card, 6px cho button, 4px cho badge. Không dùng bo cong kiểu "app trẻ em" — góc vuông hơn = nghiêm túc hơn. Viền luôn là 0.5px, chỉ dày hơn (1.5px) khi cần nhấn mạnh focus state hoặc accent.
Về typography: Ưu tiên Be Vietnam Pro vì hỗ trợ tiếng Việt đẹp. Màu chữ chính là #1A3A6B (không phải đen tuyệt đối) — tạo cảm giác nhất quán với palette thay vì đứt đoạn thị giác.
Quy tắc vàng: Mỗi màn hình chỉ nên có một điểm nhấn navy duy nhất (nút call-to-action chính). Tất cả thứ khác phải nhạt hơn hoặc trung tính hơn nó.