### PR TITLE
### Kiến trúc 4 không gian danh riêng cho sinh viên:

### DIFF
--- a/src/app/Http/Controllers/Student/StudentPageController.php
+++ b/src/app/Http/Controllers/Student/StudentPageController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Student;
 
 use App\Http\Controllers\Controller;
+use App\Models\CourseSection;
 use App\Models\User;
 use App\Services\StudentDashboardService;
 use Illuminate\Contracts\View\View;
@@ -20,6 +21,23 @@ class StudentPageController extends Controller
         return view('student.classes.index', $this->studentDashboardService->getClassesData($user));
     }
 
+    /**
+     * Class Workspace — 3-tab detail view for a single course section.
+     */
+    public function classShow(CourseSection $section): View
+    {
+        /** @var User $user */
+        $user = Auth::user();
+
+        // Verify student is enrolled
+        $isEnrolled = $user->enrolledSections()->where('course_sections.id', $section->id)->exists();
+        abort_unless($isEnrolled, 403, 'Bạn không thuộc lớp học phần này.');
+
+        $data = $this->studentDashboardService->getClassShowData($user, $section);
+
+        return view('student.classes.show', $data);
+    }
+
     public function results(): View
     {
         return view('student.results.index-placeholder');
@@ -28,5 +46,10 @@ class StudentPageController extends Controller
     public function attendance(): View
     {
         return view('student.attendance.index-placeholder');
+    }
+
+    public function complaints(): View
+    {
+        return view('student.complaints.index');
     }
 }

--- a/src/app/Services/StudentDashboardService.php
+++ b/src/app/Services/StudentDashboardService.php
@@ -2,12 +2,17 @@
 
 namespace App\Services;
 
-use App\Models\Exam;
+use App\Models\CourseSection;
+use App\Models\ExamSchedule;
+use App\Models\Notification;
 use App\Models\User;
+use Carbon\Carbon;
 
 class StudentDashboardService
 {
     /**
+     * Dashboard data — urgency-driven.
+     *
      * @return array<string, mixed>
      */
     public function getDashboardData(User $user): array
@@ -15,22 +20,47 @@ class StudentDashboardService
         $enrolledSections = $user->enrolledSections()->withCount('students')->with('lecturer')->get();
         $sectionIds = $enrolledSections->pluck('id');
 
-        $schedules = \App\Models\ExamSchedule::whereIn('course_section_id', $sectionIds)
-            ->whereHas('exam', function ($query) {
-                $query->published();
-            })
-            ->with(['exam.subject'])
+        // All schedules (backward compat)
+        $schedules = ExamSchedule::whereIn('course_section_id', $sectionIds)
+            ->whereHas('exam', fn ($q) => $q->published())
+            ->with(['exam.subject', 'courseSection'])
             ->orderByDesc('exam_date')
             ->orderByDesc('start_time')
             ->get();
 
+        // Upcoming exams — not yet ended, ordered by nearest first, max 6
+        $upcomingExams = ExamSchedule::whereIn('course_section_id', $sectionIds)
+            ->whereHas('exam', fn ($q) => $q->published())
+            ->where(function ($q) {
+                $q->where('exam_date', '>', now()->toDateString())
+                    ->orWhere(function ($q2) {
+                        $q2->where('exam_date', now()->toDateString())
+                            ->where('end_time', '>=', now()->toTimeString());
+                    });
+            })
+            ->with(['exam.subject', 'courseSection'])
+            ->orderBy('exam_date')
+            ->orderBy('start_time')
+            ->limit(6)
+            ->get();
+
+        // Recent notifications for this user
+        $recentNotifications = Notification::where('user_id', $user->id)
+            ->orderByDesc('created_at')
+            ->limit(5)
+            ->get();
+
         return [
-            'enrolledSections' => $enrolledSections,
-            'schedules' => $schedules,
+            'enrolledSections'     => $enrolledSections,
+            'schedules'            => $schedules,
+            'upcomingExams'        => $upcomingExams,
+            'recentNotifications'  => $recentNotifications,
         ];
     }
 
     /**
+     * Classes list data.
+     *
      * @return array<string, mixed>
      */
     public function getClassesData(User $user): array
@@ -40,6 +70,79 @@ class StudentDashboardService
                 ->withCount('students')
                 ->with('lecturer')
                 ->get(),
+        ];
+    }
+
+    /**
+     * Class Workspace data — 3 tabs (Feed, Exams, Grades).
+     *
+     * @return array<string, mixed>
+     */
+    public function getClassShowData(User $user, CourseSection $section): array
+    {
+        // Notifications/Feed for this section (for this student)
+        $notifications = Notification::where('user_id', $user->id)
+            ->where('data->course_section_id', $section->id)
+            ->orderByDesc('created_at')
+            ->limit(20)
+            ->get();
+
+        // Exam schedules for this section
+        $examSchedules = ExamSchedule::where('course_section_id', $section->id)
+            ->whereHas('exam', fn ($q) => $q->published())
+            ->with(['exam.subject'])
+            ->orderByDesc('exam_date')
+            ->orderByDesc('start_time')
+            ->get();
+
+        // Determine status for each schedule for this student
+        $examSchedules->each(function ($schedule) use ($user) {
+            $now = now();
+            $examDate = $schedule->exam_date->format('Y-m-d');
+            $startDt = Carbon::parse($examDate . ' ' . $schedule->start_time);
+            $endDt = Carbon::parse($examDate . ' ' . $schedule->end_time);
+
+            if ($schedule->status === 'cancelled') {
+                $schedule->student_status = 'cancelled';
+                $schedule->student_status_label = 'Đã hủy';
+            } elseif ($now->lt($startDt)) {
+                $schedule->student_status = 'upcoming';
+                $schedule->student_status_label = 'Sắp mở';
+            } elseif ($now->between($startDt, $endDt)) {
+                // Check if student has completed
+                $completed = $schedule->isCompletedBy($user->id);
+                if ($completed) {
+                    $schedule->student_status = 'submitted';
+                    $schedule->student_status_label = 'Đã nộp';
+                } else {
+                    $schedule->student_status = 'in_progress';
+                    $schedule->student_status_label = 'Đang diễn ra';
+                }
+            } else {
+                $completed = $schedule->isCompletedBy($user->id);
+                if ($completed) {
+                    $schedule->student_status = 'graded';
+                    $schedule->student_status_label = 'Đã có điểm';
+                } else {
+                    $schedule->student_status = 'ended';
+                    $schedule->student_status_label = 'Đã kết thúc';
+                }
+            }
+        });
+
+        // Grades — completed attempts for this student in this section's exams
+        $completedAttempts = \App\Models\ExamAttempt::where('user_id', $user->id)
+            ->whereHas('schedule', fn ($q) => $q->where('course_section_id', $section->id))
+            ->where('status', 'completed')
+            ->with(['schedule.exam'])
+            ->orderByDesc('completed_at')
+            ->get();
+
+        return [
+            'section'           => $section->load(['subject', 'lecturer', 'semester']),
+            'notifications'     => $notifications,
+            'examSchedules'     => $examSchedules,
+            'completedAttempts' => $completedAttempts,
         ];
     }
 }

--- a/src/resources/views/layouts/app.blade.php
+++ b/src/resources/views/layouts/app.blade.php
@@ -28,6 +28,16 @@ $lecturerSidebarSubjects = \App\Models\Subject::query()
 ->get(['id', 'name', 'code']);
 }
 }
+
+$isStudentUser = auth()->check() && auth()->user()->hasRole('student');
+$studentSidebarSections = collect();
+
+if ($isStudentUser) {
+$studentSidebarSections = auth()->user()->enrolledSections()
+->with(['subject:id,name,code', 'lecturer:id,name'])
+->orderByDesc('updated_at')
+->get();
+}
 @endphp
 
 <!DOCTYPE html>
@@ -253,18 +263,89 @@ $lecturerSidebarSubjects = \App\Models\Subject::query()
                     @endif
 
                     @role('student')
-                    <x-sidebar-section label="Menu chính">
-                        <x-sidebar-link route="student.dashboard" icon="grid">Tổng quan</x-sidebar-link>
-                        <x-sidebar-link route="student.classes.index" icon="book-open">Học phần của tôi</x-sidebar-link>
-                        <x-sidebar-link route="student.exams.index" icon="clipboard-list">Kỳ thi & Bài tập</x-sidebar-link>
-                        <x-sidebar-link route="student.schedules.index" icon="clock">Lịch thi</x-sidebar-link>
-                        <x-sidebar-link route="student.results.index" icon="chart-bar">Kết quả học tập</x-sidebar-link>
-                        <x-sidebar-link route="student.attendance.index" icon="check-circle">Điểm danh</x-sidebar-link>
-                    </x-sidebar-section>
+                    <div class="px-3">
+                        <a href="{{ route('student.dashboard') }}"
+                            class="sidebar-link {{ request()->routeIs('student.dashboard') ? 'active' : '' }}">
+                            <div class="w-[48px] flex items-center justify-center flex-shrink-0">
+                                <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zm10 0a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zm10 0a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z" />
+                                </svg>
+                            </div>
+                            <span class="sidebar-label truncate flex-1 transition-opacity duration-300 pr-4" x-show="isExpanded" x-cloak>Tổng quan</span>
+                        </a>
+                    </div>
 
-                    <x-sidebar-section label="Cài đặt">
-                        <x-sidebar-link route="profile.edit" icon="user">Hồ sơ cá nhân</x-sidebar-link>
-                    </x-sidebar-section>
+                    <div class="px-2 py-1 space-y-1">
+                        <button type="button"
+                            class="sidebar-link w-full"
+                            @click="openClassMenu = !openClassMenu">
+                            <div class="w-[48px] flex items-center justify-center flex-shrink-0">
+                                <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25" />
+                                </svg>
+                            </div>
+                            <span class="sidebar-label flex-1 text-left transition-opacity duration-300 pr-2" x-show="isExpanded" x-cloak>Lớp học của tôi</span>
+                            <svg x-show="isExpanded" x-cloak class="w-4 h-4 mr-3 text-text-muted transition-transform" :class="openClassMenu ? 'rotate-180' : ''" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                            </svg>
+                        </button>
+
+                        <div x-show="openClassMenu" x-transition.opacity.duration.150ms class="space-y-1 pl-2 pr-1" style="display:none;">
+                            @forelse($studentSidebarSections as $section)
+                            @php
+                            $sectionRouteModel = request()->route('section');
+                            $sectionActive = request()->routeIs('student.classes.show')
+                            && ((int) optional($sectionRouteModel)->id === (int) $section->id);
+                            @endphp
+                            <a href="{{ route('student.classes.show', $section) }}"
+                                class="sidebar-link {{ $sectionActive ? 'active' : '' }}">
+                                <div class="w-[48px] flex items-center justify-center flex-shrink-0">
+                                    <div class="w-1.5 h-1.5 rounded-full bg-blue-400"></div>
+                                </div>
+                                <span class="sidebar-label flex-1 min-w-0 transition-opacity duration-300 pr-3" x-show="isExpanded" x-cloak>
+                                    <span class="block truncate">{{ $section->name ?? $section->code }}</span>
+                                    <span class="block text-[10px] text-text-muted truncate">{{ $section->subject->name ?? $section->code }}</span>
+                                </span>
+                            </a>
+                            @empty
+                            <p class="text-[11px] text-text-muted px-3 py-2" x-show="isExpanded" x-cloak>Chưa có lớp học phần nào.</p>
+                            @endforelse
+                        </div>
+                    </div>
+
+                    <div class="px-2 py-1 space-y-1 border-t border-border-clean/60 mt-2 pt-2">
+                        <a href="{{ route('student.results.index') }}"
+                            class="sidebar-link {{ request()->routeIs('student.results.*') ? 'active' : '' }}">
+                            <div class="w-[48px] flex items-center justify-center flex-shrink-0">
+                                <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+                                </svg>
+                            </div>
+                            <span class="sidebar-label truncate flex-1 transition-opacity duration-300 pr-3" x-show="isExpanded" x-cloak>Kết quả học tập</span>
+                        </a>
+
+                        <a href="{{ route('student.complaints.index') }}"
+                            class="sidebar-link {{ request()->routeIs('student.complaints.*') ? 'active' : '' }}">
+                            <div class="w-[48px] flex items-center justify-center flex-shrink-0">
+                                <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z" />
+                                </svg>
+                            </div>
+                            <span class="sidebar-label truncate flex-1 transition-opacity duration-300 pr-3" x-show="isExpanded" x-cloak>Khiếu nại</span>
+                        </a>
+                    </div>
+
+                    <div class="px-2 py-1 space-y-1 border-t border-border-clean/60 mt-1 pt-2">
+                        <a href="{{ route('profile.edit') }}"
+                            class="sidebar-link {{ request()->routeIs('profile.*') ? 'active' : '' }}">
+                            <div class="w-[48px] flex items-center justify-center flex-shrink-0">
+                                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+                                </svg>
+                            </div>
+                            <span class="sidebar-label truncate flex-1 transition-opacity duration-300 pr-3" x-show="isExpanded" x-cloak>Hồ sơ cá nhân</span>
+                        </a>
+                    </div>
                     @endrole
                 </nav>
             </div>

--- a/src/resources/views/student/classes/index.blade.php
+++ b/src/resources/views/student/classes/index.blade.php
@@ -8,40 +8,24 @@
         <div class="flex items-center justify-between">
             <div>
                 <h2 class="text-3xl font-bold text-navy-900 leading-tight">Học phần của tôi</h2>
-                <p class="text-sm font-medium text-text-muted mt-1">Danh sách các lớp học phần bạn đã tham gia.</p>
+                <p class="text-sm font-medium text-text-muted mt-1">Danh sách các lớp học phần bạn đang theo học trong học kỳ hiện tại.</p>
             </div>
-            <x-button variant="primary" onclick="document.getElementById('join-class-modal').classList.remove('hidden')" class="flex items-center gap-2">
-                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M12 4v16m8-8H4" />
-                </svg>
-                Tham gia lớp học phần
-            </x-button>
         </div>
 
         {{-- Filters & Search --}}
         <div class="flex flex-col sm:flex-row items-center justify-between gap-4 bg-white p-4 rounded-[10px] border-[0.5px] border-border-clean shadow-sm">
             <x-search-input x-model="searchQuery" placeholder="Tìm kiếm theo tên hoặc mã lớp..." class="!max-w-md" />
-            <div class="flex items-center gap-2 text-sm text-text-muted">
-                <span>Sắp xếp:</span>
-                <select class="bg-transparent border-none text-navy-900 font-semibold focus:ring-0 cursor-pointer">
-                    <option>Mới nhất</option>
-                    <option>Cũ nhất</option>
-                    <option>Tên A-Z</option>
-                </select>
+            <div class="flex items-center gap-2 text-[11px] text-text-muted font-medium">
+                <span>{{ $enrolledSections->count() }} lớp</span>
             </div>
         </div>
-
-
 
         {{-- Class Grid --}}
         @if($enrolledSections->isEmpty())
         <div class="text-center py-20 bg-surface-0 border-[0.5px] border-border-clean border-dashed rounded-[10px]">
             <x-ui-icon name="academic-cap" class="mx-auto w-12 h-12 text-blue-200 mb-4" />
-            <p class="font-semibold text-navy-900 text-lg">Chưa tham gia lớp học phần nào</p>
-            <p class="text-sm text-text-muted mt-2 mb-6">Nhập mã lớp học để tham gia lớp học phần đầu tiên.</p>
-            <x-button variant="primary" onclick="document.getElementById('join-class-modal').classList.remove('hidden')">
-                Tham gia lớp ngay
-            </x-button>
+            <p class="font-semibold text-navy-900 text-lg">Chưa có lớp học phần nào</p>
+            <p class="text-sm text-text-muted mt-2">Lớp học phần sẽ được hiển thị khi quản trị viên phân công.</p>
         </div>
         @else
         <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">
@@ -49,109 +33,57 @@
             @php
             $searchableText = strtolower(($section->name ?? '') . ' ' . $section->code);
             @endphp
-            <x-card class="flex flex-col h-full overflow-hidden" x-show="searchQuery === '' || '{{ $searchableText }}'.includes(searchQuery.toLowerCase())">
-                {{-- Card Top --}}
-                <div class="px-5 py-4 border-b-[0.5px] border-border-clean bg-surface-1">
-                    <div class="flex items-start justify-between gap-3">
-                        <div>
-                            <p class="font-semibold text-[10px] uppercase tracking-wider text-text-muted">{{ $section->code }}</p>
-                            <h3 class="font-bold text-lg text-navy-900 leading-tight mt-1">{{ $section->name ?? $section->code }}</h3>
-                        </div>
-                        <span class="uppercase text-[10px] font-bold px-2 py-1 rounded-[4px] shrink-0
-                                    @if($section->status === 'active') bg-teal-50 text-teal-800 border-[0.5px] border-teal-200
-                                    @elseif($section->status === 'archived') bg-surface-1 text-text-muted border-[0.5px] border-border-clean
-                                    @else bg-red-50 text-red-700 border-[0.5px] border-red-200 @endif">
-                            {{ match($section->status) {
-                                        'active'   => 'Đang mở',
-                                        'archived' => 'Đã lưu trữ',
-                                        default    => 'Đã huỷ',
-                                    } }}
-                        </span>
-                    </div>
-                </div>
-
-                {{-- Card Body --}}
-                <div class="p-5 flex-1 space-y-4">
-                    <div class="flex items-center justify-between text-sm">
-                        <span class="font-medium text-text-muted">Sinh viên</span>
-                        <span class="font-bold text-navy-900">{{ $section->students_count ?? 0 }} <span class="text-text-muted font-medium">/ {{ $section->max_students }}</span></span>
-                    </div>
-                    @if($section->lecturer)
-                    <div class="flex items-center justify-between text-sm">
-                        <span class="font-medium text-text-muted">Giảng viên</span>
-                        <span class="font-semibold text-navy-900">{{ $section->lecturer->name }}</span>
-                    </div>
-                    @endif
-                </div>
-
-                {{-- Card Footer --}}
-                <div class="px-5 pb-5 pt-2 flex flex-col gap-3" x-data="{ confirmingLeave: false }">
-                    <div class="flex gap-3">
-                        <x-button variant="primary" href="{{ route('student.dashboard') }}" class="flex-1 text-center justify-center">
-                            Xem chi tiết
-                        </x-button>
-                        <x-button type="button" @click="confirmingLeave = true" x-show="!confirmingLeave" variant="outline" class="px-3 !text-red-600 !border-red-200 hover:!bg-red-50">
-                            Rời lớp
-                        </x-button>
-                    </div>
-
-                    <div x-show="confirmingLeave" x-cloak class="flex items-center justify-between bg-red-50 p-3 rounded-lg border border-red-100">
-                        <span class="text-xs font-bold text-red-700">Chắc chắn muốn rời?</span>
-                        <div class="flex gap-3">
-                            <form method="POST" action="{{ route('student.leave-class', $section) }}">
-                                @csrf
-                                @method('DELETE')
-                                <button type="submit" class="text-xs font-bold text-red-600 hover:underline">Xác nhận</button>
-                            </form>
-                            <button type="button" @click="confirmingLeave = false" class="text-xs font-medium text-navy-600 hover:underline">Hủy</button>
+            <a href="{{ route('student.classes.show', $section) }}"
+               class="block group"
+               x-show="searchQuery === '' || '{{ $searchableText }}'.includes(searchQuery.toLowerCase())">
+                <x-card class="flex flex-col h-full overflow-hidden hover:border-blue-400 hover:shadow-md transition-all">
+                    {{-- Card Top --}}
+                    <div class="px-5 py-4 border-b-[0.5px] border-border-clean bg-surface-1">
+                        <div class="flex items-start justify-between gap-3">
+                            <div>
+                                <p class="font-semibold text-[10px] uppercase tracking-wider text-text-muted">{{ $section->code }}</p>
+                                <h3 class="font-bold text-lg text-navy-900 leading-tight mt-1 group-hover:text-blue-600 transition-colors">{{ $section->name ?? $section->code }}</h3>
+                            </div>
+                            <span class="uppercase text-[10px] font-bold px-2 py-1 rounded-[4px] shrink-0
+                                        @if($section->status === 'active') bg-teal-50 text-teal-800 border-[0.5px] border-teal-200
+                                        @elseif($section->status === 'archived') bg-surface-1 text-text-muted border-[0.5px] border-border-clean
+                                        @else bg-red-50 text-red-700 border-[0.5px] border-red-200 @endif">
+                                {{ match($section->status) {
+                                            'active'   => 'Đang mở',
+                                            'archived' => 'Đã lưu trữ',
+                                            default    => 'Đã huỷ',
+                                        } }}
+                            </span>
                         </div>
                     </div>
-                </div>
-            </x-card>
+
+                    {{-- Card Body --}}
+                    <div class="p-5 flex-1 space-y-3">
+                        @if($section->lecturer)
+                        <div class="flex items-center justify-between text-sm">
+                            <span class="font-medium text-text-muted">Giảng viên</span>
+                            <span class="font-semibold text-navy-900">{{ $section->lecturer->name }}</span>
+                        </div>
+                        @endif
+                        <div class="flex items-center justify-between text-sm">
+                            <span class="font-medium text-text-muted">Sinh viên</span>
+                            <span class="font-bold text-navy-900">{{ $section->students_count ?? 0 }} <span class="text-text-muted font-medium">/ {{ $section->max_students }}</span></span>
+                        </div>
+                    </div>
+
+                    {{-- Card Footer --}}
+                    <div class="px-5 pb-4 pt-2">
+                        <div class="flex items-center justify-between text-[12px]">
+                            <span class="text-text-muted font-medium">Xem chi tiết lớp</span>
+                            <svg class="w-4 h-4 text-text-muted group-hover:text-blue-600 group-hover:translate-x-1 transition-all" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+                            </svg>
+                        </div>
+                    </div>
+                </x-card>
+            </a>
             @endforeach
         </div>
         @endif
     </div>
-
-    {{-- Modal tham gia lớp --}}
-    <div id="join-class-modal" class="hidden fixed inset-0 bg-navy-950/60 z-50 flex items-center justify-center p-4 backdrop-blur-sm">
-        <x-card padding="true" class="w-full max-w-md">
-            <div class="flex items-center justify-between mb-6">
-                <h3 class="text-lg font-semibold text-navy-900">Tham gia lớp học phần</h3>
-                <button onclick="document.getElementById('join-class-modal').classList.add('hidden')" class="text-text-muted hover:text-navy-900">
-                    <x-ui-icon name="x-mark" class="w-5 h-5" />
-                </button>
-            </div>
-
-            @if(!auth()->user()->student_code)
-            <div class="bg-amber-50 border-[0.5px] border-amber-600 rounded-[8px] p-4 text-center">
-                <p class="text-xs text-amber-600 font-medium mb-3">Trước tiên hãy hoàn tất hồ sơ sinh viên (nhập MSSV).</p>
-                <x-button variant="primary" class="w-full" href="{{ route('onboarding.show') }}">
-                    Nhập thông tin sinh viên
-                </x-button>
-            </div>
-            @else
-            <form method="POST" action="{{ route('student.join-class') }}" class="space-y-4">
-                @csrf
-                <div>
-                    <label class="block text-xs font-medium text-navy-900 mb-1">Mã lớp học</label>
-                    <x-text-input name="invite_code" type="text" :value="old('invite_code')" required placeholder="VD: ABC123" class="font-mono" />
-                    @error('invite_code')
-                    <p class="mt-1 text-xs font-medium text-red-600">{{ $message }}</p>
-                    @enderror
-                </div>
-                <div class="flex justify-end gap-2 pt-2">
-                    <x-button variant="ghost" onclick="document.getElementById('join-class-modal').classList.add('hidden')">Hủy bỏ</x-button>
-                    <x-button type="submit" variant="primary">Tham gia</x-button>
-                </div>
-            </form>
-            @endif
-        </x-card>
-    </div>
-
-    @if($errors->has('invite_code') || session('error'))
-    <script>
-        document.getElementById('join-class-modal').classList.remove('hidden');
-    </script>
-    @endif
 </x-app-layout>

--- a/src/resources/views/student/classes/show.blade.php
+++ b/src/resources/views/student/classes/show.blade.php
@@ -1,0 +1,322 @@
+<x-app-layout>
+    @section('title', ($section->name ?? $section->code) . ' — EMS')
+    @section('page-title', 'Lớp học phần')
+
+    @php
+    $activeTab = request()->query('tab', 'feed');
+    if (!in_array($activeTab, ['feed', 'exams', 'grades'], true)) {
+        $activeTab = 'feed';
+    }
+    @endphp
+
+    <div class="space-y-6" x-data="studentClassWorkspace('{{ $activeTab }}')">
+        {{-- Header --}}
+        <div class="flex flex-wrap items-start justify-between gap-4">
+            <div>
+                <a href="{{ route('student.dashboard') }}"
+                    class="inline-flex items-center gap-1.5 text-[13px] font-medium text-text-muted hover:text-navy-900 transition-colors">
+                    <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+                    </svg>
+                    Quay về tổng quan
+                </a>
+                <p class="text-[12px] font-semibold uppercase tracking-wider text-text-muted mt-4 mb-1">{{ $section->code }}</p>
+                <h2 class="text-[28px] font-bold text-navy-900 leading-tight">{{ $section->name ?? $section->code }}</h2>
+                <div class="flex flex-wrap items-center gap-2 mt-3">
+                    <span class="inline-flex items-center px-2.5 py-1 rounded-full text-[11px] font-semibold bg-blue-50 text-navy-900 border border-blue-200">
+                        {{ $section->subject->code ?? 'N/A' }} — {{ $section->subject->name ?? 'Chưa gán môn' }}
+                    </span>
+                    @if($section->lecturer)
+                    <span class="inline-flex items-center px-2.5 py-1 rounded-full text-[11px] font-semibold bg-surface-1 text-text-muted border border-border-clean">
+                        GV: {{ $section->lecturer->name }}
+                    </span>
+                    @endif
+                    @if($section->semester)
+                    <span class="inline-flex items-center px-2.5 py-1 rounded-full text-[11px] font-semibold bg-surface-1 text-text-muted border border-border-clean">
+                        {{ $section->semester->name }}
+                    </span>
+                    @endif
+                </div>
+            </div>
+        </div>
+
+        {{-- Tab Card --}}
+        <x-card padding="false" class="overflow-hidden">
+            {{-- Tab Bar --}}
+            <div class="px-4 sm:px-6 border-b border-border-clean bg-surface-1">
+                <div class="flex flex-wrap items-center gap-2 py-2">
+                    <button type="button"
+                        @click="switchTab('feed')"
+                        :class="activeTab === 'feed' ? 'bg-white text-navy-900 border-border-clean' : 'text-text-muted border-transparent'"
+                        class="h-9 px-4 border rounded-[6px] text-[13px] font-semibold transition-colors">
+                        <span class="flex items-center gap-1.5">
+                            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" /></svg>
+                            Bảng tin
+                        </span>
+                    </button>
+                    <button type="button"
+                        @click="switchTab('exams')"
+                        :class="activeTab === 'exams' ? 'bg-white text-navy-900 border-border-clean' : 'text-text-muted border-transparent'"
+                        class="h-9 px-4 border rounded-[6px] text-[13px] font-semibold transition-colors">
+                        <span class="flex items-center gap-1.5">
+                            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01" /></svg>
+                            Kỳ thi
+                            @if($examSchedules->where('student_status', 'in_progress')->count() > 0)
+                            <span class="ml-1 bg-teal-500 text-white text-[9px] font-bold px-1.5 py-0.5 rounded-full">{{ $examSchedules->where('student_status', 'in_progress')->count() }}</span>
+                            @endif
+                        </span>
+                    </button>
+                    <button type="button"
+                        @click="switchTab('grades')"
+                        :class="activeTab === 'grades' ? 'bg-white text-navy-900 border-border-clean' : 'text-text-muted border-transparent'"
+                        class="h-9 px-4 border rounded-[6px] text-[13px] font-semibold transition-colors">
+                        <span class="flex items-center gap-1.5">
+                            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" /></svg>
+                            Điểm số
+                        </span>
+                    </button>
+                </div>
+            </div>
+
+            {{-- ═══ TAB 1: Bảng tin (Feed) ═══ --}}
+            <div class="p-4 sm:p-6 space-y-4" x-show="activeTab === 'feed'" x-transition.opacity.duration.150ms>
+                @if($notifications->isEmpty())
+                <div class="text-center py-12 bg-surface-0 border-[0.5px] border-border-clean border-dashed rounded-[8px]">
+                    <x-ui-icon name="bell-slash" class="w-10 h-10 text-blue-100 mx-auto mb-3" />
+                    <p class="text-sm text-text-muted font-medium">Chưa có thông báo nào từ giảng viên.</p>
+                </div>
+                @else
+                <div class="space-y-3">
+                    @foreach($notifications as $notification)
+                    <div class="border-[0.5px] border-border-clean rounded-[8px] p-4 bg-white hover:bg-surface-0 transition-colors">
+                        <div class="flex items-center gap-2 mb-2">
+                            <span class="text-[10px] font-bold text-text-muted uppercase tracking-wider">
+                                {{ $notification->created_at->format('H:i — d/m/Y') }}
+                            </span>
+                        </div>
+                        <h4 class="text-sm font-bold text-navy-900 mb-1">{{ $notification->title }}</h4>
+                        <p class="text-xs text-text-muted leading-relaxed whitespace-pre-wrap">{{ $notification->message }}</p>
+                    </div>
+                    @endforeach
+                </div>
+                @endif
+            </div>
+
+            {{-- ═══ TAB 2: Kỳ thi ═══ --}}
+            <div class="p-4 sm:p-6 space-y-4" x-show="activeTab === 'exams'" x-transition.opacity.duration.150ms style="display:none;">
+                @if($examSchedules->isEmpty())
+                <div class="text-center py-12 bg-surface-0 border-[0.5px] border-border-clean border-dashed rounded-[8px]">
+                    <x-ui-icon name="document-text" class="w-10 h-10 text-blue-100 mx-auto mb-3" />
+                    <p class="text-sm text-text-muted font-medium">Chưa có kỳ thi nào cho lớp này.</p>
+                </div>
+                @else
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    @foreach($examSchedules as $schedule)
+                    <div class="border-[0.5px] border-border-clean rounded-[10px] p-5 bg-white flex flex-col justify-between hover:shadow-sm transition-shadow
+                        {{ $schedule->student_status === 'in_progress' ? 'border-teal-300 bg-teal-50/20' : '' }}">
+                        <div class="mb-4">
+                            <div class="flex items-center justify-between mb-2">
+                                @php
+                                $statusConfig = match($schedule->student_status) {
+                                    'upcoming'    => ['bg-blue-50 text-blue-700 border-blue-200', 'Sắp mở'],
+                                    'in_progress' => ['bg-teal-50 text-teal-700 border-teal-200', 'Đang diễn ra'],
+                                    'submitted'   => ['bg-gray-50 text-gray-600 border-gray-200', 'Đã nộp'],
+                                    'graded'      => ['bg-teal-50 text-teal-800 border-teal-200', 'Đã có điểm'],
+                                    'ended'       => ['bg-gray-50 text-gray-500 border-gray-200', 'Đã kết thúc'],
+                                    'cancelled'   => ['bg-red-50 text-red-700 border-red-200', 'Đã hủy'],
+                                    default       => ['bg-surface-1 text-text-muted border-border-clean', 'N/A'],
+                                };
+                                @endphp
+                                <span class="inline-flex items-center gap-1 text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 rounded-full border {{ $statusConfig[0] }}">
+                                    @if($schedule->student_status === 'in_progress')
+                                    <span class="w-1.5 h-1.5 rounded-full bg-teal-500 animate-pulse"></span>
+                                    @endif
+                                    {{ $statusConfig[1] }}
+                                </span>
+                                <span class="text-[11px] text-text-muted font-semibold">{{ $schedule->exam_date->format('d/m/Y') }}</span>
+                            </div>
+                            <h4 class="font-bold text-base text-navy-900 leading-snug mb-1">{{ $schedule->exam->title }}</h4>
+                            <div class="flex items-center gap-3 mt-2 text-[11px] text-text-muted">
+                                <span class="font-semibold">{{ \Carbon\Carbon::parse($schedule->start_time)->format('H:i') }} — {{ \Carbon\Carbon::parse($schedule->end_time)->format('H:i') }}</span>
+                                <span>·</span>
+                                <span>{{ $schedule->exam->duration_minutes }} phút</span>
+                                <span>·</span>
+                                <span>{{ $schedule->exam->questions_count ?? '?' }} câu</span>
+                            </div>
+                        </div>
+
+                        @if($schedule->student_status === 'in_progress')
+                        <a href="{{ route('student.exams.show', $schedule->id) }}"
+                           class="inline-flex items-center justify-center gap-2 w-full px-4 py-2.5 bg-navy-900 text-white text-sm font-semibold rounded-[6px] hover:bg-navy-950 transition-colors shadow-sm">
+                            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12H9m12 0a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+                            Vào thi
+                        </a>
+                        @elseif(in_array($schedule->student_status, ['submitted', 'graded']))
+                        <a href="{{ route('student.exams.result', $schedule->id) }}"
+                           class="inline-flex items-center justify-center gap-2 w-full px-4 py-2 bg-surface-1 text-navy-900 text-sm font-semibold rounded-[6px] hover:bg-blue-50 border border-border-clean transition-colors">
+                            Xem kết quả
+                        </a>
+                        @elseif($schedule->student_status === 'upcoming')
+                        <div class="text-center text-xs text-text-muted font-medium py-2 bg-surface-0 rounded-[6px] border border-border-clean border-dashed">
+                            Chưa đến giờ thi
+                        </div>
+                        @endif
+                    </div>
+                    @endforeach
+                </div>
+                @endif
+            </div>
+
+            {{-- ═══ TAB 3: Điểm số ═══ --}}
+            <div class="p-4 sm:p-6 space-y-4" x-show="activeTab === 'grades'" x-transition.opacity.duration.150ms style="display:none;">
+                @if($completedAttempts->isEmpty())
+                <div class="text-center py-12 bg-surface-0 border-[0.5px] border-border-clean border-dashed rounded-[8px]">
+                    <x-ui-icon name="chart-bar" class="w-10 h-10 text-blue-100 mx-auto mb-3" />
+                    <p class="text-sm text-text-muted font-medium">Chưa có điểm số nào.</p>
+                    <p class="text-xs text-text-muted mt-1">Hoàn thành bài thi để xem điểm tại đây.</p>
+                </div>
+                @else
+                <div class="overflow-x-auto border border-border-clean rounded-[8px]">
+                    <table class="w-full text-left border-collapse">
+                        <thead>
+                            <tr class="bg-surface-1 border-b border-border-clean">
+                                <th class="py-3 px-4 text-[11px] font-semibold uppercase tracking-wider text-text-muted">Bài thi</th>
+                                <th class="py-3 px-4 text-[11px] font-semibold uppercase tracking-wider text-text-muted text-center">Điểm</th>
+                                <th class="py-3 px-4 text-[11px] font-semibold uppercase tracking-wider text-text-muted text-center">Kết quả</th>
+                                <th class="py-3 px-4 text-[11px] font-semibold uppercase tracking-wider text-text-muted text-center">Nộp lúc</th>
+                                <th class="py-3 px-4 text-[11px] font-semibold uppercase tracking-wider text-text-muted text-center"></th>
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y divide-border-clean/70">
+                            @foreach($completedAttempts as $attempt)
+                            @php
+                                $exam = $attempt->schedule->exam;
+                                $passed = $attempt->total_score >= ($exam->pass_points ?? 0);
+                            @endphp
+                            <tr class="hover:bg-surface-0 transition-colors">
+                                <td class="py-3 px-4">
+                                    <p class="text-[13px] font-semibold text-navy-900">{{ $exam->title }}</p>
+                                    <p class="text-[11px] text-text-muted mt-0.5">Lần {{ $attempt->attempt_number }}</p>
+                                </td>
+                                <td class="py-3 px-4 text-center">
+                                    <span class="text-lg font-bold {{ $passed ? 'text-teal-600' : 'text-red-500' }}">
+                                        {{ number_format($attempt->total_score, 2) }}
+                                    </span>
+                                </td>
+                                <td class="py-3 px-4 text-center">
+                                    @if($passed)
+                                    <span class="inline-flex items-center text-[10px] font-bold uppercase px-2 py-1 rounded-[4px] bg-teal-50 text-teal-800 border border-teal-200">ĐẠT</span>
+                                    @else
+                                    <span class="inline-flex items-center text-[10px] font-bold uppercase px-2 py-1 rounded-[4px] bg-red-50 text-red-700 border border-red-200">CHƯA ĐẠT</span>
+                                    @endif
+                                </td>
+                                <td class="py-3 px-4 text-center text-[12px] text-text-muted">
+                                    {{ $attempt->completed_at?->format('H:i — d/m/Y') }}
+                                </td>
+                                <td class="py-3 px-4 text-center">
+                                    <div class="flex items-center justify-center gap-2">
+                                        <a href="{{ route('student.exams.result', $attempt->exam_schedule_id) }}"
+                                           class="text-[12px] font-semibold text-blue-600 hover:text-blue-700">Chi tiết</a>
+                                        <button type="button"
+                                            @click="openComplaintModal('{{ addslashes($exam->title) }}', '{{ $attempt->total_score }}', '{{ $attempt->exam_schedule_id }}')"
+                                            class="text-[12px] font-medium text-text-muted hover:text-red-600 transition-colors">
+                                            Gửi khiếu nại
+                                        </button>
+                                    </div>
+                                </td>
+                            </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+                @endif
+            </div>
+        </x-card>
+
+        {{-- ═══ Modal Khiếu nại (Không gian 4) ═══ --}}
+        <x-modal name="complaint-modal" maxWidth="lg">
+            <div class="p-6 md:p-8">
+                <div class="flex items-center justify-between mb-6">
+                    <h3 class="text-[20px] font-bold text-navy-900">Gửi khiếu nại điểm</h3>
+                    <button @click="$dispatch('close-modal', 'complaint-modal')" class="text-text-muted hover:text-navy-900 transition-colors">
+                        <svg class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                        </svg>
+                    </button>
+                </div>
+
+                <div class="space-y-4">
+                    <div class="p-3 bg-surface-1 border border-border-clean rounded-lg space-y-2">
+                        <div class="flex justify-between text-[12px]">
+                            <span class="text-text-muted font-medium">Lớp học phần:</span>
+                            <span class="font-semibold text-navy-900">{{ $section->name ?? $section->code }}</span>
+                        </div>
+                        <div class="flex justify-between text-[12px]">
+                            <span class="text-text-muted font-medium">Bài thi:</span>
+                            <span class="font-semibold text-navy-900" x-text="complaintExamTitle">—</span>
+                        </div>
+                        <div class="flex justify-between text-[12px]">
+                            <span class="text-text-muted font-medium">Điểm hiện tại:</span>
+                            <span class="font-bold text-red-500" x-text="complaintCurrentScore">—</span>
+                        </div>
+                    </div>
+
+                    <div>
+                        <label class="block text-[12px] font-semibold text-navy-900 mb-1.5">Lý do khiếu nại <span class="text-red-500">*</span></label>
+                        <textarea x-model="complaintReason" rows="4" placeholder="Vui lòng mô tả chi tiết lý do bạn muốn phúc khảo bài thi này..."
+                            class="w-full p-3 bg-white border-[1.5px] border-border-clean rounded-[6px] text-[13px] text-navy-900 placeholder:text-text-muted focus:border-blue-400 focus:ring-4 focus:ring-blue-100/50 transition-all outline-none resize-y"></textarea>
+                    </div>
+
+                    <div class="flex justify-end gap-3 pt-2">
+                        <x-button type="button" variant="ghost" @click="$dispatch('close-modal', 'complaint-modal')">Hủy</x-button>
+                        <x-button type="button" variant="primary" @click="submitComplaint()">
+                            Gửi khiếu nại
+                        </x-button>
+                    </div>
+                </div>
+            </div>
+        </x-modal>
+    </div>
+
+    <script>
+        function studentClassWorkspace(initialTab) {
+            return {
+                activeTab: initialTab || 'feed',
+                complaintExamTitle: '',
+                complaintCurrentScore: '',
+                complaintScheduleId: '',
+                complaintReason: '',
+
+                switchTab(tab) {
+                    this.activeTab = tab;
+                    const url = new URL(window.location.href);
+                    url.searchParams.set('tab', tab);
+                    window.history.replaceState({}, '', url);
+                },
+
+                openComplaintModal(examTitle, score, scheduleId) {
+                    this.complaintExamTitle = examTitle;
+                    this.complaintCurrentScore = score;
+                    this.complaintScheduleId = scheduleId;
+                    this.complaintReason = '';
+                    this.$dispatch('open-modal', 'complaint-modal');
+                },
+
+                submitComplaint() {
+                    if (!this.complaintReason || this.complaintReason.trim().length < 10) {
+                        window.dispatchEvent(new CustomEvent('toast', {
+                            detail: { message: 'Vui lòng nhập lý do khiếu nại (ít nhất 10 ký tự).', type: 'error' }
+                        }));
+                        return;
+                    }
+
+                    // UI-only for now — backend not implemented yet
+                    this.$dispatch('close-modal', 'complaint-modal');
+                    window.dispatchEvent(new CustomEvent('toast', {
+                        detail: { message: 'Tính năng khiếu nại đang được phát triển. Vui lòng liên hệ giảng viên trực tiếp.', type: 'warning' }
+                    }));
+                },
+            }
+        }
+    </script>
+</x-app-layout>

--- a/src/resources/views/student/complaints/index.blade.php
+++ b/src/resources/views/student/complaints/index.blade.php
@@ -1,0 +1,26 @@
+<x-app-layout>
+    @section('title', 'Khiếu nại — EMS')
+    @section('page-title', 'Khiếu nại')
+
+    <div class="space-y-6">
+        <div class="flex items-center justify-between">
+            <div>
+                <h2 class="text-3xl font-bold text-navy-900 leading-tight">Khiếu nại của tôi</h2>
+                <p class="text-sm font-medium text-text-muted mt-1">Theo dõi tiến trình xử lý các đơn khiếu nại về điểm thi.</p>
+            </div>
+        </div>
+
+        <x-card padding="true">
+            <div class="text-center py-16 bg-surface-0 border-[0.5px] border-border-clean border-dashed rounded-[8px]">
+                <svg class="w-14 h-14 text-blue-100 mx-auto mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z" />
+                </svg>
+                <p class="text-navy-900 font-semibold text-base mb-2">Tính năng đang được phát triển</p>
+                <p class="text-sm text-text-muted max-w-md mx-auto">
+                    Bạn có thể gửi khiếu nại nhanh từ Tab <strong>"Điểm số"</strong> trong trang chi tiết lớp học phần.
+                    Hệ thống quản lý khiếu nại đầy đủ sẽ sớm ra mắt.
+                </p>
+            </div>
+        </x-card>
+    </div>
+</x-app-layout>

--- a/src/resources/views/student/dashboard.blade.php
+++ b/src/resources/views/student/dashboard.blade.php
@@ -1,11 +1,12 @@
 <x-app-layout>
-    @section('title', 'Dashboard - Sinh vien')
-    @section('page-title', 'Tong quan hoc tap')
+    @section('title', 'Tổng quan — Sinh viên')
+    @section('page-title', 'Tổng quan học tập')
 
-    <div class="space-y-6" x-data="{ searchQuery: '' }">
+    <div class="space-y-6">
 
+        {{-- Hero Section --}}
         <x-card padding="true" variant="featured">
-            <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-6">
+            <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
                 <div>
                     <h2 class="text-2xl md:text-3xl font-bold text-navy-900 leading-tight">Xin chào, {{ auth()->user()->name }}!</h2>
                     <p class="mt-2 text-sm text-text-muted">
@@ -21,177 +22,145 @@
                     </p>
                 </div>
 
-                <div class="flex items-center gap-3">
-                    <x-button variant="outline" onclick="document.getElementById('join-class-modal').classList.remove('hidden')">
-                        + Tham gia lớp
-                    </x-button>
-                    <x-button variant="secondary" href="{{ route('profile.edit') }}">
-                        Hồ sơ
-                    </x-button>
+                <div class="flex items-center gap-4 text-sm">
+                    <div class="flex items-center gap-2 px-3 py-2 bg-white border border-border-clean rounded-lg">
+                        <svg class="w-4 h-4 text-blue-500" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25" /></svg>
+                        <span class="font-bold text-navy-900">{{ $enrolledSections->count() }}</span>
+                        <span class="text-text-muted">lớp</span>
+                    </div>
+                    <div class="flex items-center gap-2 px-3 py-2 bg-white border border-border-clean rounded-lg">
+                        <svg class="w-4 h-4 text-amber-500" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01" /></svg>
+                        <span class="font-bold text-navy-900">{{ $upcomingExams->count() }}</span>
+                        <span class="text-text-muted">bài thi sắp tới</span>
+                    </div>
                 </div>
             </div>
         </x-card>
 
-        {{-- $enrolledSections và $exams được truyền từ controller --}}
-
-        <section class="grid grid-cols-1 md:grid-cols-3 gap-6">
-            <x-card padding="true">
-                <p class="text-xs font-medium text-text-muted mb-1">Học phần đang theo</p>
-                <div class="flex items-baseline gap-2">
-                    <p class="text-3xl font-bold text-navy-900 leading-none">{{ $enrolledSections->count() }}</p>
-                    <span class="text-xs text-text-muted">lớp</span>
-                </div>
-            </x-card>
-            <x-card padding="true" variant="accent">
-                <p class="text-xs font-medium text-text-muted mb-1">Bài thi</p>
-                <div class="flex items-baseline gap-2">
-                    <p class="text-3xl font-bold text-navy-900 leading-none">{{ $schedules->count() }}</p>
-                    <span class="text-xs text-text-muted">bài</span>
-                </div>
-            </x-card>
-            <x-card padding="true">
-                <p class="text-xs font-medium text-text-muted mb-1">Chuyên cần</p>
-                <div class="flex items-baseline gap-2">
-                    <p class="text-3xl font-bold text-navy-900 leading-none">-%</p>
-                    <span class="text-xs text-text-muted">đã tham gia</span>
-                </div>
-            </x-card>
-        </section>
-
+        {{-- ═══ URGENCY: Kỳ thi sắp tới ═══ --}}
         <x-card padding="true">
             <x-slot name="header">
-                <h3 class="text-lg font-semibold text-navy-900">Bài Kiểm Tra & Kỳ Thi</h3>
+                <div class="flex items-center gap-2">
+                    <svg class="w-5 h-5 text-red-500" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
+                    <h3 class="text-lg font-semibold text-navy-900">Kỳ thi sắp tới</h3>
+                </div>
             </x-slot>
 
-            @if($schedules->isEmpty())
+            @if($upcomingExams->isEmpty())
             <div class="text-center py-10 bg-surface-0 border-[0.5px] border-border-clean border-dashed rounded-[8px]">
-                <p class="text-text-muted text-sm font-medium">Bạn chưa có bài thi nào.</p>
+                <x-ui-icon name="check-circle" class="w-10 h-10 text-teal-300 mx-auto mb-3" />
+                <p class="text-text-muted text-sm font-medium">Không có kỳ thi nào sắp tới. Yên tâm!</p>
             </div>
             @else
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-                @foreach($schedules as $schedule)
-                <div class="border-[0.5px] border-border-clean p-4 rounded-[8px] bg-white hover:border-blue-200 transition-colors flex flex-col justify-between">
+                @foreach($upcomingExams as $schedule)
+                @php
+                    $now = now();
+                    $examDateStr = $schedule->exam_date->format('Y-m-d');
+                    $startDt = \Carbon\Carbon::parse($examDateStr . ' ' . $schedule->start_time);
+                    $endDt = \Carbon\Carbon::parse($examDateStr . ' ' . $schedule->end_time);
+
+                    $isOpen = $now->between($startDt, $endDt);
+                    $isUpcoming = $now->lt($startDt);
+                    $hoursUntil = $now->diffInHours($startDt, false);
+                    $isUrgent = $isUpcoming && $hoursUntil >= 0 && $hoursUntil <= 24;
+                    $isCompleted = $schedule->isCompletedBy(auth()->id());
+                @endphp
+                <div class="border-[0.5px] rounded-[10px] p-5 bg-white flex flex-col justify-between transition-all hover:shadow-md
+                    {{ $isUrgent && !$isCompleted ? 'border-red-300 bg-red-50/30' : ($isOpen && !$isCompleted ? 'border-teal-300 bg-teal-50/20' : 'border-border-clean') }}">
                     <div class="mb-4">
                         <div class="flex items-center justify-between mb-2">
-                            @if($schedule->isCompletedBy(auth()->id()))
-                            <x-badge type="success">Đã hoàn thành</x-badge>
-                            @elseif($schedule->is_not_started)
-                            <x-badge type="neutral">Chưa đến giờ</x-badge>
-                            @elseif($schedule->time_left_minutes > 0)
-                            <x-badge type="warning">{{ $schedule->time_left_text }}</x-badge>
+                            @if($isCompleted)
+                            <span class="inline-flex items-center gap-1 text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 rounded-full bg-teal-50 text-teal-700 border border-teal-200">
+                                <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M5 13l4 4L19 7"/></svg>
+                                Đã nộp
+                            </span>
+                            @elseif($isOpen)
+                            <span class="inline-flex items-center gap-1 text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 rounded-full bg-teal-50 text-teal-700 border border-teal-200 animate-pulse">
+                                <span class="w-1.5 h-1.5 rounded-full bg-teal-500"></span>
+                                Đang mở
+                            </span>
+                            @elseif($isUrgent)
+                            <span class="inline-flex items-center gap-1 text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 rounded-full bg-red-50 text-red-700 border border-red-200">
+                                <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z"/></svg>
+                                Sắp tới
+                            </span>
                             @else
-                            <x-badge type="danger">Đã hết giờ</x-badge>
+                            <span class="inline-flex items-center text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 rounded-full bg-blue-50 text-blue-700 border border-blue-200">
+                                Sắp tới
+                            </span>
                             @endif
-                            <span class="text-xs text-text-muted">{{ $schedule->exam_date?->format('d/m/Y') ?? 'Chưa xác định' }}</span>
+                            <span class="text-[11px] text-text-muted font-semibold">{{ $schedule->exam_date->format('d/m/Y') }}</span>
                         </div>
-                        <h4 class="font-semibold text-base text-navy-900 leading-snug mb-1">{{ $schedule->exam->title }}</h4>
-                        <p class="text-xs text-text-muted">{{ $schedule->exam->subject->name ?? '—' }}</p>
+                        <h4 class="font-bold text-base text-navy-900 leading-snug mb-1">{{ $schedule->exam->title }}</h4>
+                        <p class="text-xs text-text-muted">{{ $schedule->courseSection->name ?? '—' }}</p>
+                        <div class="flex items-center gap-3 mt-2 text-[11px] text-text-muted">
+                            <span class="font-semibold">{{ \Carbon\Carbon::parse($schedule->start_time)->format('H:i') }} — {{ \Carbon\Carbon::parse($schedule->end_time)->format('H:i') }}</span>
+                            <span>·</span>
+                            <span>{{ $schedule->exam->duration_minutes }} phút</span>
+                        </div>
                     </div>
 
-                    <x-button variant="primary" size="sm" class="w-full" href="{{ route('student.exams.show', $schedule->id) }}">
-                        Vào Phòng Thi
-                    </x-button>
+                    @if($isOpen && !$isCompleted)
+                    <a href="{{ route('student.exams.show', $schedule->id) }}"
+                       class="inline-flex items-center justify-center gap-2 w-full px-4 py-2.5 bg-navy-900 text-white text-sm font-semibold rounded-[6px] hover:bg-navy-950 transition-colors shadow-sm">
+                        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12H9m12 0a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+                        Vào phòng thi
+                    </a>
+                    @elseif($isCompleted)
+                    <a href="{{ route('student.exams.result', $schedule->id) }}"
+                       class="inline-flex items-center justify-center gap-2 w-full px-4 py-2 bg-surface-1 text-navy-900 text-sm font-semibold rounded-[6px] hover:bg-blue-50 border border-border-clean transition-colors">
+                        Xem kết quả
+                    </a>
+                    @else
+                    <div class="text-center text-xs text-text-muted font-medium py-2 bg-surface-0 rounded-[6px] border border-border-clean border-dashed">
+                        Chưa đến giờ thi
+                    </div>
+                    @endif
                 </div>
                 @endforeach
             </div>
             @endif
         </x-card>
 
+        {{-- ═══ Thông báo mới nhất ═══ --}}
         <x-card padding="true">
             <x-slot name="header">
-                <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-                    <h3 class="text-lg font-semibold text-navy-900">Lớp học phần của tôi</h3>
-                    <x-search-input x-model="searchQuery" placeholder="Tìm theo tên hoặc mã lớp..." class="!max-w-[240px]" />
+                <div class="flex items-center justify-between">
+                    <div class="flex items-center gap-2">
+                        <svg class="w-5 h-5 text-blue-500" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" /></svg>
+                        <h3 class="text-lg font-semibold text-navy-900">Thông báo mới nhất</h3>
+                    </div>
+                    <a href="{{ route('student.notifications.index') }}" class="text-xs font-bold text-blue-600 hover:text-navy-900 uppercase tracking-wider">Xem tất cả →</a>
                 </div>
             </x-slot>
 
-            @if($enrolledSections->isEmpty())
-            <div class="text-center py-10">
-                <p class="text-text-muted text-sm mb-4">Bạn chưa tham gia lớp nào.</p>
-                <x-button variant="primary" onclick="document.getElementById('join-class-modal').classList.remove('hidden')">
-                    Tham gia lớp ngay
-                </x-button>
+            @if($recentNotifications->isEmpty())
+            <div class="text-center py-8 bg-surface-0 border-[0.5px] border-border-clean border-dashed rounded-[8px]">
+                <p class="text-text-muted text-sm font-medium">Chưa có thông báo nào.</p>
             </div>
             @else
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                @foreach($enrolledSections as $section)
+            <div class="divide-y-[0.5px] divide-border-clean">
+                @foreach($recentNotifications as $notification)
                 @php
-                $searchableText = strtolower(($section->name ?? '') . ' ' . $section->code);
+                    $data = is_array($notification->data) ? $notification->data : json_decode($notification->data, true);
+                    $className = $data['course_section_name'] ?? 'Hệ thống';
                 @endphp
-                <div class="border-[0.5px] border-border-clean bg-surface-0 rounded-[8px] p-4 flex items-center justify-between gap-4"
-                    x-show="searchQuery === '' || '{{ $searchableText }}'.includes(searchQuery.toLowerCase())"
-                    x-data="{ confirmingLeave: false }">
-                    <div>
-                        <p class="font-semibold text-sm text-navy-900 leading-tight">{{ $section->name ?? $section->code }}</p>
-                        <p class="text-xs text-text-muted mt-1 font-mono">{{ $section->code }}</p>
-                        @if($section->lecturer)
-                        <p class="text-xs text-text-muted mt-0.5">Giảng viên: {{ $section->lecturer->name }}</p>
-                        @endif
-                    </div>
-                    
-                    <div class="flex items-center gap-2">
-                        <button type="button" 
-                                x-show="!confirmingLeave"
-                                @click="confirmingLeave = true"
-                                class="text-xs font-medium text-red-600 hover:text-red-700 hover:underline">
-                            Rời lớp
-                        </button>
-
-                        <div x-show="confirmingLeave" x-cloak class="flex items-center gap-2">
-                            <span class="text-xs text-text-muted font-medium">Chắc chắn?</span>
-                            <form method="POST" action="{{ route('student.leave-class', $section) }}">
-                                @csrf
-                                @method('DELETE')
-                                <button type="submit" class="text-xs font-bold text-red-600 hover:text-red-700">Rời</button>
-                            </form>
-                            <button type="button" @click="confirmingLeave = false" class="text-xs font-medium text-navy-400 hover:text-navy-600">Hủy</button>
+                <div class="py-3.5 flex items-start gap-3">
+                    <div class="w-2 h-2 rounded-full bg-blue-400 mt-2 flex-shrink-0"></div>
+                    <div class="flex-1 min-w-0">
+                        <div class="flex items-center gap-2 mb-1">
+                            <span class="inline-block px-1.5 py-0.5 bg-blue-50 text-blue-700 border-[0.5px] border-blue-200 rounded text-[9px] font-bold uppercase tracking-wider">{{ $className }}</span>
+                            <span class="text-[10px] text-text-muted">{{ $notification->created_at->diffForHumans() }}</span>
                         </div>
+                        <h4 class="text-sm font-semibold text-navy-900 truncate">{{ $notification->title }}</h4>
+                        <p class="text-xs text-text-muted line-clamp-1 mt-0.5">{{ $notification->message }}</p>
                     </div>
                 </div>
                 @endforeach
             </div>
             @endif
         </x-card>
+
     </div>
-
-    <div id="join-class-modal" class="hidden fixed inset-0 bg-navy-950/60 z-50 flex items-center justify-center p-4 backdrop-blur-sm">
-        <x-card padding="true" class="w-full max-w-md">
-            <div class="flex items-center justify-between mb-6">
-                <h3 class="text-lg font-semibold text-navy-900">Tham gia lớp học</h3>
-                <button onclick="document.getElementById('join-class-modal').classList.add('hidden')" class="text-text-muted hover:text-navy-900">
-                    <x-ui-icon name="x-mark" class="w-5 h-5" />
-                </button>
-            </div>
-
-            @if(!auth()->user()->student_code)
-            <div class="bg-amber-50 border-[0.5px] border-amber-600 rounded-[8px] p-4 text-center">
-                <p class="text-xs text-amber-600 font-medium mb-3">Trước tiên hãy hoàn tất hồ sơ sinh viên (nhập MSSV).</p>
-                <x-button variant="primary" class="w-full" href="{{ route('onboarding.show') }}">
-                    Nhập thông tin sinh viên
-                </x-button>
-            </div>
-            @else
-            <form method="POST" action="{{ route('student.join-class') }}" class="space-y-4">
-                @csrf
-                <div>
-                    <label class="block text-xs font-medium text-navy-900 mb-1">Mã lớp học</label>
-                    <x-text-input name="invite_code" type="text" :value="old('invite_code')" required placeholder="VD: ABC123" class="font-mono" />
-                    @error('invite_code')
-                    <p class="mt-1 text-xs font-medium text-red-600">{{ $message }}</p>
-                    @enderror
-                </div>
-                <div class="flex justify-end gap-2 pt-2">
-                    <x-button variant="ghost" onclick="document.getElementById('join-class-modal').classList.add('hidden')">Hủy bỏ</x-button>
-                    <x-button type="submit" variant="primary">Tham gia</x-button>
-                </div>
-            </form>
-            @endif
-        </x-card>
-    </div>
-
-    @if($errors->has('invite_code') || session('error'))
-    <script>
-        document.getElementById('join-class-modal').classList.remove('hidden');
-    </script>
-    @endif
 </x-app-layout>

--- a/src/resources/views/student/exams/room.blade.php
+++ b/src/resources/views/student/exams/room.blade.php
@@ -7,660 +7,500 @@ $totalQuestions = count($questions);
 <head>
     <meta charset="utf-8" />
     <meta content="width=device-width, initial-scale=1.0" name="viewport" />
-    <title>{{ $exam->title }} - EduPortal</title>
-    <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet" />
-    <link href="https://fonts.googleapis.com/css2?family=Be+Vietnam+Pro:wght@400;500;600;700&display=swap" rel="stylesheet">
-    <style data-purpose="custom-styles">
-        * {
-            box-sizing: border-box;
-        }
+    <title>{{ $exam->title }} — Phòng thi</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <style>
+        *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
         body {
-            background-color: #F8FAFD;
-            font-family: 'Be Vietnam Pro', 'Inter', system-ui, sans-serif;
-            color: #374151;
-            margin: 0;
-        }
-
-        .text-h1 {
-            font-size: 28px;
-            font-weight: 700;
-            line-height: 1.2;
+            font-family: 'Inter', system-ui, sans-serif;
+            background: #F4F7FC;
             color: #1A3A6B;
+            overflow: hidden;
+            height: 100vh;
         }
 
-        .text-h2 {
-            font-size: 22px;
-            font-weight: 600;
-            line-height: 1.3;
-            color: #1A3A6B;
-        }
-
-        .text-h3 {
-            font-size: 17px;
-            font-weight: 600;
-            color: #1A3A6B;
-        }
-
-        .text-body {
-            font-size: 14px;
-            color: #374151;
-            line-height: 1.6;
-        }
-
-        .text-caption {
-            font-size: 12px;
-            color: #6B7C99;
-        }
-
-        .text-mono {
-            font-size: 13px;
-            color: #1A3A6B;
-            font-family: monospace;
-        }
-
-        /* Navbar */
-        .nav-bar {
+        /* ── Slim Top Bar ── */
+        .zen-bar {
+            height: 44px;
             background: #1A3A6B;
             display: flex;
             align-items: center;
+            justify-content: space-between;
             padding: 0 20px;
-            height: 52px;
-            gap: 8px;
+            flex-shrink: 0;
         }
-
-        .nav-logo {
+        .zen-bar-left {
             display: flex;
             align-items: center;
-            gap: 8px;
-            margin-right: 24px;
+            gap: 10px;
         }
-
-        .nav-dot {
-            width: 8px;
-            height: 8px;
-            border-radius: 50%;
-            background: #34D399;
-        }
-
-        .nav-logo-text {
+        .zen-bar-dot { width: 6px; height: 6px; border-radius: 50%; background: #34D399; }
+        .zen-bar-title {
             color: #fff;
-            font-size: 15px;
+            font-size: 13px;
             font-weight: 600;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            max-width: 400px;
         }
-
-        .nav-right {
-            margin-left: auto;
+        .zen-bar-right {
             display: flex;
             align-items: center;
-            gap: 8px;
+            gap: 12px;
         }
-
-        .nav-user-role {
-            background: rgba(255, 255, 255, 0.1);
-            border-radius: 5px;
-            padding: 4px 10px;
-            display: flex;
-            align-items: center;
-            gap: 6px;
-        }
-
-        .nav-role-dot {
-            width: 5px;
-            height: 5px;
-            border-radius: 50%;
-            background: #34D399;
-        }
-
-        .nav-role-text {
-            color: #93BAE8;
-            font-size: 11px;
-        }
-
-        .nav-avatar {
-            width: 30px;
-            height: 30px;
+        .zen-bar-avatar {
+            width: 28px; height: 28px;
             border-radius: 50%;
             background: #2A5298;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            color: #93BAE8;
-            font-size: 11px;
-            font-weight: 600;
+            display: flex; align-items: center; justify-content: center;
+            color: #93BAE8; font-size: 10px; font-weight: 700;
             border: 1.5px solid #3A6AC8;
             text-transform: uppercase;
         }
 
-        /* Cards */
-        .ca-card {
+        /* ── Main Layout: 2 Columns ── */
+        .zen-layout {
+            display: flex;
+            height: calc(100vh - 44px);
+            overflow: hidden;
+        }
+
+        /* Left Column — Questions (large) */
+        .zen-left {
+            flex: 1;
+            min-width: 0;
+            overflow-y: auto;
+            padding: 32px 48px;
+        }
+
+        /* Right Column — Controls (fixed, narrow) */
+        .zen-right {
+            width: 300px;
+            flex-shrink: 0;
             background: #fff;
-            border: 0.5px solid #D6E2F0;
-            border-radius: 10px;
-            padding: 16px;
+            border-left: 1px solid #D6E2F0;
+            display: flex;
+            flex-direction: column;
+            overflow-y: auto;
         }
 
-        .ca-card-accent {
-            background: #fff;
-            border: 0.5px solid #D6E2F0;
-            border-radius: 10px;
-            padding: 16px;
-            border-top: 3px solid #1A3A6B;
+        /* ── Timer ── */
+        .timer-block {
+            padding: 20px;
+            text-align: center;
+            border-bottom: 1px solid #D6E2F0;
+            background: #F8FAFD;
         }
-
-        .ca-card-featured {
-            background: #F4F7FC;
-            border: 0.5px solid #B5D4F4;
-            border-radius: 10px;
-            padding: 16px;
+        .timer-label {
+            font-size: 10px;
+            font-weight: 700;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            color: #6B7C99;
+            margin-bottom: 6px;
         }
-
-        /* Buttons */
-        .btn {
-            display: inline-flex;
-            align-items: center;
-            justify-content: center;
-            gap: 6px;
-            font-size: 13px;
-            font-weight: 500;
-            padding: 8px 18px;
-            border-radius: 6px;
-            cursor: pointer;
-            border: none;
-            font-family: inherit;
-            transition: opacity .15s;
-            outline: none;
-        }
-
-        .btn-primary {
-            background: #1A3A6B;
-            color: #fff;
-        }
-
-        .btn-secondary {
-            background: #E6F1FB;
+        .timer-display {
+            font-size: 42px;
+            font-weight: 700;
             color: #1A3A6B;
+            letter-spacing: 2px;
+            font-variant-numeric: tabular-nums;
+            transition: color 0.3s;
         }
-
-        .btn-outline {
-            background: transparent;
-            color: #1A3A6B;
-            border: 1.5px solid #1A3A6B;
-        }
-
-        .btn-ghost {
-            background: transparent;
-            color: #1A3A6B;
-            border: 1.5px solid #D6E2F0;
-        }
-
-        .btn-danger {
-            background: #FEE2E2;
-            color: #991B1B;
-        }
-
-        .btn-sm {
-            font-size: 11px;
-            padding: 5px 12px;
-            border-radius: 5px;
-        }
-
-        .btn-lg {
-            font-size: 15px;
-            padding: 11px 24px;
-            border-radius: 8px;
-        }
-
-        .btn:disabled {
-            opacity: 0.5;
-            cursor: not-allowed;
-        }
-
-        /* Form inputs */
-        .ca-input {
-            border: 1.5px solid #D6E2F0;
-            border-radius: 6px;
-            padding: 8px 12px;
-            font-size: 13px;
-            color: #1A3A6B;
-            background: #fff;
-            font-family: inherit;
-            outline: none;
-            width: 100%;
-            transition: all 0.2s;
-            resize: none;
-        }
-
-        .ca-input:focus {
-            border-color: #185FA5;
-            box-shadow: 0 0 0 3px #E6F1FB;
-        }
-
-        /* Status */
-        .status {
+        .timer-display.urgent { color: #DC2626; }
+        .timer-status {
             display: inline-flex;
             align-items: center;
             gap: 5px;
             font-size: 11px;
             font-weight: 500;
-            padding: 3px 9px;
+            padding: 3px 10px;
             border-radius: 20px;
-        }
-
-        .status-dot {
-            width: 5px;
-            height: 5px;
-            border-radius: 50%;
-            flex-shrink: 0;
-        }
-
-        .s-ongoing {
             background: #D1FAE5;
             color: #065F46;
+            margin-top: 8px;
         }
+        .timer-status-dot { width: 5px; height: 5px; border-radius: 50%; background: #10B981; }
 
-        .s-ongoing .status-dot {
-            background: #10B981;
+        /* ── Question Map ── */
+        .qmap-block {
+            padding: 16px 20px;
+            flex: 1;
+            overflow-y: auto;
         }
-
-        /* Question Navigator */
-        .question-btn {
-            width: 42px;
-            height: 42px;
-            display: inline-flex;
+        .qmap-header {
+            display: flex;
+            justify-content: space-between;
             align-items: center;
-            justify-content: center;
+            margin-bottom: 12px;
+        }
+        .qmap-title { font-size: 13px; font-weight: 700; color: #1A3A6B; }
+        .qmap-count { font-size: 11px; color: #6B7C99; }
+        .qmap-count strong { color: #1A3A6B; }
+
+        .qmap-grid {
+            display: grid;
+            grid-template-columns: repeat(5, 1fr);
+            gap: 8px;
+        }
+        .q-btn {
+            width: 100%; aspect-ratio: 1;
+            display: flex; align-items: center; justify-content: center;
             border-radius: 6px;
-            font-weight: 500;
-            font-size: 13px;
+            font-weight: 600; font-size: 13px;
             border: 1.5px solid #D6E2F0;
-            background-color: #fff;
-            color: #6B7C99;
-            position: relative;
-            transition: all 0.2s;
+            background: #fff; color: #6B7C99;
             cursor: pointer;
-            padding: 0;
+            transition: all 0.15s;
+            position: relative;
             font-family: inherit;
         }
-
-        .question-btn:hover {
-            background-color: #F8FAFD;
-            border-color: #185FA5;
-            color: #1A3A6B;
-        }
-
-        .question-btn.answered {
-            background-color: #E1F5EE;
-            color: #085041;
-            border-color: #1D9E75;
-        }
-
-        .question-btn.current {
-            background-color: #1A3A6B;
-            color: #fff;
-            border-color: #1A3A6B;
-            font-weight: 600;
-        }
-
-        .question-btn.flagged {
-            border-color: #D97706;
-        }
-
-        .flag-indicator {
-            position: absolute;
-            top: -1px;
-            right: -1px;
-            width: 0;
-            height: 0;
-            border-top: 14px solid #D97706;
-            border-left: 14px solid transparent;
+        .q-btn:hover { border-color: #185FA5; color: #1A3A6B; background: #F8FAFD; }
+        .q-btn.answered { background: #E1F5EE; color: #085041; border-color: #1D9E75; }
+        .q-btn.current { background: #1A3A6B; color: #fff; border-color: #1A3A6B; }
+        .q-btn.flagged { border-color: #D97706; }
+        .q-btn.flagged::after {
+            content: '';
+            position: absolute; top: -1px; right: -1px;
+            border-top: 12px solid #D97706;
+            border-left: 12px solid transparent;
             border-top-right-radius: 5px;
-            display: none;
         }
 
-        .question-btn.flagged .flag-indicator {
-            display: block;
+        .qmap-legend {
+            display: flex; flex-wrap: wrap; gap: 12px;
+            margin-top: 16px; padding-top: 12px;
+            border-top: 1px solid #D6E2F0;
+            font-size: 11px; color: #6B7C99;
         }
+        .qmap-legend-item { display: flex; align-items: center; gap: 5px; }
+        .legend-box {
+            width: 12px; height: 12px; border-radius: 3px;
+            border: 1.5px solid #D6E2F0; background: #fff;
+        }
+        .legend-box.answered { border-color: #1D9E75; background: #E1F5EE; }
+        .legend-box.current { border-color: #1A3A6B; background: #1A3A6B; }
+        .legend-box.flagged { border-color: #D97706; }
 
-        .flag-icon-xs {
-            font-size: 7px;
+        /* ── Submit Button ── */
+        .submit-block {
+            padding: 16px 20px;
+            border-top: 1px solid #D6E2F0;
+            background: #F8FAFD;
+        }
+        .btn-submit {
+            width: 100%;
+            padding: 12px;
+            background: #1A3A6B;
             color: #fff;
-            position: absolute;
-            top: 1px;
-            right: 2px;
-            z-index: 10;
-            display: none;
-        }
-
-        .question-btn.flagged .flag-icon-xs {
-            display: block;
-        }
-
-        /* Option Cards */
-        .option-card {
-            border: 1.5px solid #D6E2F0;
+            border: none;
             border-radius: 8px;
-            padding: 12px 16px;
-            margin-bottom: 12px;
-            display: flex;
-            align-items: center;
-            cursor: pointer;
-            background-color: #fff;
-            transition: all 0.2s;
-            min-height: 48px;
-        }
-
-        .option-card:hover {
-            border-color: #185FA5;
-            background-color: #F8FAFD;
-        }
-
-        .option-card.selected {
-            background-color: #E6F1FB;
-            border-color: #185FA5;
-        }
-
-        .custom-radio {
-            appearance: none;
-            width: 20px;
-            height: 20px;
-            border: 1.5px solid #D6E2F0;
-            border-radius: 50%;
-            margin-right: 12px;
-            outline: none;
-            position: relative;
-            flex-shrink: 0;
-            cursor: pointer;
-            background-color: #fff;
-            transition: all 0.15s;
-        }
-
-        .option-card:hover .custom-radio {
-            border-color: #185FA5;
-        }
-
-        .custom-radio:checked {
-            border-color: #185FA5;
-            border-width: 5px;
-        }
-
-        .question-container {
-            display: none;
-        }
-
-        .question-container.active {
-            display: flex;
-            flex-direction: column;
-            animation: fadeIn 0.3s ease-out;
-        }
-
-        @keyframes fadeIn {
-            from {
-                opacity: 0;
-                transform: translateY(4px);
-            }
-
-            to {
-                opacity: 1;
-                transform: translateY(0);
-            }
-        }
-
-        /* Layout */
-        .main-layout {
-            display: flex;
-            gap: 24px;
-            max-width: 1400px;
-            margin: 32px auto;
-            padding: 0 24px;
-            align-items: flex-start;
-        }
-
-        .col-left {
-            width: 320px;
-            flex-shrink: 0;
-        }
-
-        .col-center {
-            flex: 1;
-            min-width: 0;
-        }
-
-        .col-right {
-            width: 280px;
-            flex-shrink: 0;
-        }
-
-        .timer-display {
-            font-size: 40px;
+            font-size: 14px;
             font-weight: 700;
-            color: #DC2626;
+            font-family: inherit;
+            cursor: pointer;
+            transition: background 0.15s;
+        }
+        .btn-submit:hover { background: #0F2A53; }
+        .submit-note {
             text-align: center;
-            letter-spacing: 2px;
+            font-size: 11px;
+            color: #6B7C99;
             margin-top: 8px;
         }
 
-        .toast {
-            position: absolute;
-            top: 24px;
-            right: 24px;
-            padding: 10px 16px;
-            border-radius: 8px;
-            font-size: 13px;
-            font-weight: 500;
+        /* ── Question Content ── */
+        .question-container { display: none; }
+        .question-container.active {
+            display: flex; flex-direction: column;
+            animation: fadeSlide 0.25s ease-out;
+        }
+        @keyframes fadeSlide {
+            from { opacity: 0; transform: translateY(6px); }
+            to { opacity: 1; transform: translateY(0); }
+        }
+
+        .question-header {
             display: flex;
+            justify-content: space-between;
             align-items: center;
-            gap: 8px;
-            z-index: 50;
+            padding-bottom: 20px;
+            margin-bottom: 28px;
+            border-bottom: 1px solid #D6E2F0;
+        }
+        .question-number { font-size: 22px; font-weight: 700; color: #1A3A6B; }
+        .question-badge {
+            font-size: 12px; color: #6B7C99; font-weight: 500;
+            background: #F4F7FC; padding: 4px 12px; border-radius: 20px;
+        }
+
+        .btn-flag {
+            display: inline-flex; align-items: center; gap: 6px;
+            padding: 5px 12px; border-radius: 5px;
+            font-size: 12px; font-weight: 500;
+            color: #6B7C99; background: transparent;
+            border: 1.5px solid #D6E2F0;
+            cursor: pointer; font-family: inherit;
+            transition: all 0.15s;
+        }
+        .btn-flag:hover { border-color: #D97706; color: #D97706; }
+        .btn-flag.active { border-color: #D97706; color: #D97706; background: #FEF3C7; }
+
+        .question-text {
+            font-size: 16px;
+            font-weight: 500;
+            line-height: 1.7;
+            color: #1A3A6B;
+            margin-bottom: 32px;
+        }
+
+        /* ── Option Cards ── */
+        .option-card {
+            border: 1.5px solid #D6E2F0;
+            border-radius: 10px;
+            padding: 14px 18px;
+            margin-bottom: 12px;
+            display: flex; align-items: center;
+            cursor: pointer;
+            background: #fff;
+            transition: all 0.2s;
+            min-height: 52px;
+        }
+        .option-card:hover { border-color: #185FA5; background: #F8FAFD; }
+        .option-card.selected { background: #E6F1FB; border-color: #185FA5; }
+
+        .custom-radio {
+            appearance: none;
+            width: 20px; height: 20px;
+            border: 1.5px solid #D6E2F0;
+            border-radius: 50%;
+            margin-right: 14px;
+            outline: none;
+            flex-shrink: 0;
+            cursor: pointer;
+            background: #fff;
+            transition: all 0.15s;
+        }
+        .option-card:hover .custom-radio { border-color: #185FA5; }
+        .custom-radio:checked { border-color: #185FA5; border-width: 5px; }
+        .custom-radio:focus { box-shadow: 0 0 0 3px #E6F1FB; border-color: #185FA5; }
+
+        .option-text { font-size: 14px; color: #374151; line-height: 1.5; }
+
+        /* ── Navigation Buttons ── */
+        .nav-buttons {
+            display: flex; gap: 12px;
+            margin-top: 40px;
+            padding-top: 24px;
+            border-top: 1px solid #D6E2F0;
+        }
+        .btn-nav {
+            flex: 1; height: 44px;
+            display: inline-flex; align-items: center; justify-content: center; gap: 8px;
+            font-size: 13px; font-weight: 600;
+            border-radius: 8px;
+            cursor: pointer; font-family: inherit;
+            transition: all 0.15s;
+            border: 1.5px solid #D6E2F0;
+            background: transparent; color: #1A3A6B;
+        }
+        .btn-nav:hover { background: #F4F7FC; border-color: #185FA5; }
+        .btn-nav:disabled { opacity: 0.4; cursor: not-allowed; }
+        .btn-nav.primary { background: #1A3A6B; color: #fff; border-color: #1A3A6B; }
+        .btn-nav.primary:hover { background: #0F2A53; }
+
+        /* ── Toast ── */
+        .toast {
+            position: fixed; top: 56px; right: 20px;
+            padding: 10px 16px; border-radius: 8px;
+            font-size: 13px; font-weight: 500;
+            display: flex; align-items: center; gap: 8px;
+            z-index: 100;
             transition: all 0.3s;
-            opacity: 0;
-            transform: translateY(-10px);
+            opacity: 0; transform: translateY(-10px);
             pointer-events: none;
             border: 0.5px solid #059669;
-            background: #D1FAE5;
-            color: #065F46;
+            background: #D1FAE5; color: #065F46;
         }
+        .toast.show { opacity: 1; transform: translateY(0); }
+        .toast.error { border-color: #DC2626; background: #FEF2F2; color: #991B1B; }
+        .toast.warning { border-color: #D97706; background: #FEF3C7; color: #78350F; }
 
-        .toast.show {
-            opacity: 1;
-            transform: translateY(0);
-        }
-
-        .toast.error {
-            border-color: #DC2626;
-            background: #FEF2F2;
-            color: #991B1B;
-        }
-
-        .toast.warning {
-            border-color: #D97706;
-            background: #FEF3C7;
-            color: #78350F;
-        }
-
-        .grid-nav {
-            display: grid;
-            grid-template-columns: repeat(5, 1fr);
-            gap: 10px;
-        }
-
-        @media (max-width: 1100px) {
-            .grid-nav {
-                grid-template-columns: repeat(4, 1fr);
+        /* ── Mobile ── */
+        @media (max-width: 768px) {
+            .zen-layout { flex-direction: column; }
+            .zen-left { padding: 20px 16px; flex: 1; }
+            .zen-right {
+                width: 100%;
+                border-left: none;
+                border-top: 1px solid #D6E2F0;
+                position: fixed;
+                bottom: 0; left: 0; right: 0;
+                height: auto;
+                max-height: 60vh;
+                z-index: 50;
+                border-radius: 16px 16px 0 0;
+                box-shadow: 0 -4px 24px rgba(0,0,0,0.1);
+                transform: translateY(calc(100% - 60px));
+                transition: transform 0.3s ease;
             }
+            .zen-right.expanded { transform: translateY(0); }
+            .zen-right-handle {
+                display: flex;
+                justify-content: center;
+                padding: 8px;
+                cursor: pointer;
+            }
+            .zen-right-handle-bar {
+                width: 36px; height: 4px;
+                border-radius: 2px; background: #D6E2F0;
+            }
+            .qmap-grid { grid-template-columns: repeat(7, 1fr); }
+        }
+        @media (min-width: 769px) {
+            .zen-right-handle { display: none; }
         }
     </style>
 </head>
 
 <body>
-
-    <div class="nav-bar">
-        <div class="nav-logo">
-            <div class="nav-dot"></div>
-            <span class="nav-logo-text">EduPortal</span>
+    {{-- ─── Slim Top Bar (Zen Mode) ─── --}}
+    <div class="zen-bar">
+        <div class="zen-bar-left">
+            <div class="zen-bar-dot"></div>
+            <span class="zen-bar-title">{{ $exam->title }}</span>
         </div>
-        <div class="nav-right">
-            <div class="nav-user-role">
-                <div class="nav-role-dot"></div>
-                <span class="nav-role-text">Sinh viên</span>
-            </div>
-            <div class="nav-avatar" title="{{ Auth::user()->name ?? 'Sinh viên' }}">
+        <div class="zen-bar-right">
+            <span style="color:#93BAE8; font-size:11px; font-weight:500;">{{ $exam->subject->name ?? '' }}</span>
+            <div class="zen-bar-avatar" title="{{ Auth::user()->name ?? 'SV' }}">
                 {{ strtoupper(substr(Auth::user()->name ?? 'SV', 0, 2)) }}
             </div>
         </div>
     </div>
 
-    <main class="main-layout" id="main-content">
+    {{-- ─── 2-Column Layout ─── --}}
+    <div class="zen-layout" id="main-content">
         <div id="exam-config" data-total-questions="{{ $totalQuestions }}" data-time-left="{{ $timeLeftSeconds }}" hidden></div>
 
-        <!-- Left Column: Navigation -->
-        <div class="col-left">
-            <div class="ca-card">
-                <div style="margin-bottom: 24px; display: flex; align-items: center; justify-content: space-between;">
-                    <h2 class="text-h3" style="margin: 0;">Danh sách câu hỏi</h2>
-                    <span class="text-caption">Đã làm: <span id="answered-count" style="color: #1A3A6B; font-weight: 600;">0</span>/{{ $totalQuestions }}</span>
+        {{-- ═══ Left Column: Questions ═══ --}}
+        <div class="zen-left">
+            <form id="exam-form" action="{{ route('student.exams.submit', $schedule->id) }}" method="POST">
+                @csrf
+
+                @foreach($questions as $index => $question)
+                <div class="question-container {{ $index === 0 ? 'active' : '' }}" id="question-{{ $index }}">
+
+                    <div class="question-header">
+                        <div style="display:flex; align-items:center; gap:12px;">
+                            <span class="question-number">Câu {{ $index + 1 }}</span>
+                            <span class="question-badge">/ {{ $totalQuestions }}</span>
+                        </div>
+                        <button type="button" data-flag-index="{{ $index }}" id="flag-btn-{{ $index }}" class="btn-flag">
+                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 15s1-1 4-1 5 2 8 2 4-1 4-1V3s-1 1-4 1-5-2-8-2-4 1-4 1z"/><line x1="4" y1="22" x2="4" y2="15"/></svg>
+                            <span class="flag-label">Đặt cờ</span>
+                        </button>
+                    </div>
+
+                    <div class="question-text">{!! $question->content !!}</div>
+
+                    <div style="display:flex; flex-direction:column; gap:8px;">
+                        @foreach($question->options as $option)
+                        @php $isChecked = isset($savedAnswers[$question->id]) && $savedAnswers[$question->id] == $option->id; @endphp
+                        <label class="option-card {{ $isChecked ? 'selected' : '' }}" data-option-index="{{ $index }}">
+                            <input type="radio"
+                                name="answers[{{ $question->id }}]"
+                                value="{{ $option->id }}"
+                                data-question-id="{{ $question->id }}"
+                                class="answer-radio custom-radio"
+                                {{ $isChecked ? 'checked' : '' }}>
+                            <span class="option-text">{!! $option->content !!}</span>
+                        </label>
+                        @endforeach
+                    </div>
+                </div>
+                @endforeach
+            </form>
+
+            {{-- Navigation Controls --}}
+            <div class="nav-buttons">
+                <button type="button" data-action="prev-question" id="btn-prev" class="btn-nav">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 12H5M12 19l-7-7 7-7"/></svg>
+                    Câu trước
+                </button>
+                <button type="button" data-action="next-question" id="btn-next" class="btn-nav primary">
+                    Câu tiếp
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+                </button>
+            </div>
+        </div>
+
+        {{-- ═══ Right Column: Timer + Map + Submit ═══ --}}
+        <div class="zen-right" id="zen-panel">
+            {{-- Mobile handle --}}
+            <div class="zen-right-handle" id="panel-handle">
+                <div class="zen-right-handle-bar"></div>
+            </div>
+
+            {{-- Timer --}}
+            <div class="timer-block">
+                <div class="timer-label">Thời gian còn lại</div>
+                <div id="countdown-timer" class="timer-display">--:--</div>
+                <div class="timer-status">
+                    <span class="timer-status-dot"></span>
+                    Đang thi
+                </div>
+            </div>
+
+            {{-- Question Map --}}
+            <div class="qmap-block">
+                <div class="qmap-header">
+                    <span class="qmap-title">Bản đồ câu hỏi</span>
+                    <span class="qmap-count">Đã làm: <strong id="answered-count">0</strong>/{{ $totalQuestions }}</span>
                 </div>
 
-                <div class="grid-nav" id="question-navigator">
+                <div class="qmap-grid" id="question-navigator">
                     @foreach($questions as $index => $question)
                     <button type="button"
-                        class="question-btn {{ $index === 0 ? 'current' : '' }} {{ isset($savedAnswers[$question->id]) ? 'answered' : '' }}"
+                        class="q-btn {{ $index === 0 ? 'current' : '' }} {{ isset($savedAnswers[$question->id]) ? 'answered' : '' }}"
                         data-question-index="{{ $index }}"
                         id="nav-btn-{{ $index }}">
                         {{ $index + 1 }}
-                        <div class="flag-indicator"></div>
-                        <i class="fa-solid fa-flag flag-icon-xs"></i>
                     </button>
                     @endforeach
                 </div>
 
-                <hr style="border: none; border-top: 0.5px solid #D6E2F0; margin: 24px 0;">
-
-                <div style="display: flex; flex-direction: column; gap: 12px; font-size: 12px; color: #4A5F7A;">
-                    <div style="display: flex; align-items: center; gap: 8px;">
-                        <div style="width: 14px; height: 14px; border: 1.5px solid #D6E2F0; border-radius: 3px; background: #fff;"></div>
-                        <span>Chưa trả lời</span>
-                    </div>
-                    <div style="display: flex; align-items: center; gap: 8px;">
-                        <div style="width: 14px; height: 14px; border: 1.5px solid #1D9E75; border-radius: 3px; background: #E1F5EE;"></div>
-                        <span>Đã trả lời</span>
-                    </div>
-                    <div style="display: flex; align-items: center; gap: 8px;">
-                        <div style="width: 14px; height: 14px; border: 1.5px solid #D97706; border-radius: 3px; background: #fff;"></div>
-                        <span>Đã gắn cờ</span>
-                    </div>
-                    <div style="display: flex; align-items: center; gap: 8px;">
-                        <div style="width: 14px; height: 14px; border: 1.5px solid #1A3A6B; border-radius: 3px; background: #1A3A6B;"></div>
-                        <span>Câu hiện tại</span>
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <!-- Center Column -->
-        <div class="col-center">
-            <div class="ca-card ca-card-accent" style="min-height: 60vh; display: flex; flex-direction: column; position: relative;">
-
-                <form id="exam-form" action="{{ route('student.exams.submit', $schedule->id) }}" method="POST" style="flex: 1; display: flex; flex-direction: column;">
-                    @csrf
-
-                    @foreach($questions as $index => $question)
-                    <div class="question-container {{ $index === 0 ? 'active' : '' }}" id="question-{{ $index }}" style="flex: 1;">
-
-                        <!-- Header -->
-                        <div style="display: flex; justify-content: space-between; align-items: center; border-bottom: 0.5px solid #D6E2F0; padding-bottom: 20px; margin-bottom: 24px;">
-                            <h2 class="text-h2" style="margin: 0;">Câu {{ $index + 1 }}</h2>
-                            <button type="button" data-flag-index="{{ $index }}" id="flag-btn-{{ $index }}" class="btn btn-ghost btn-sm" style="display: flex; gap: 6px;">
-                                <i class="fa-regular fa-flag"></i> Đặt cờ
-                            </button>
-                        </div>
-
-                        <!-- Content -->
-                        <div class="question-text-content" style="margin-bottom: 32px; font-size: 15px; color: #1A3A6B; font-weight: 500; line-height: 1.6;">
-                            {!! $question->content !!}
-                        </div>
-
-                        <!-- Options -->
-                        <div style="display: flex; flex-direction: column; gap: 8px; flex: 1;">
-                            @foreach($question->options as $option)
-                            @php
-                            $isChecked = isset($savedAnswers[$question->id]) && $savedAnswers[$question->id] == $option->id;
-                            @endphp
-                            <label class="option-card {{ $isChecked ? 'selected' : '' }}" data-option-index="{{ $index }}">
-                                <input type="radio"
-                                    name="answers[{{ $question->id }}]"
-                                    value="{{ $option->id }}"
-                                    data-question-id="{{ $question->id }}"
-                                    class="answer-radio custom-radio"
-                                    {{ $isChecked ? 'checked' : '' }}>
-                                <span style="font-size: 14px; color: #374151;">{!! $option->content !!}</span>
-                            </label>
-                            @endforeach
-                        </div>
-                    </div>
-                    @endforeach
-                </form>
-
-                <!-- Navigation Controls -->
-                <div style="display: flex; gap: 12px; margin-top: 32px; padding-top: 24px; border-top: 0.5px solid #D6E2F0;">
-                    <button type="button" data-action="prev-question" id="btn-prev" class="btn btn-outline" style="flex: 1; height: 44px;">
-                        <i class="fa-solid fa-arrow-left" style="margin-right: 6px;"></i> Câu trước
-                    </button>
-                    <button type="button" data-action="next-question" id="btn-next" class="btn btn-primary" style="flex: 1; height: 44px;">
-                        Câu tiếp theo <i class="fa-solid fa-arrow-right" style="margin-left: 6px;"></i>
-                    </button>
-                </div>
-
-                <!-- Toast Positioned Relative to Card -->
-                <div id="save-toast" class="toast">
-                    <i class="fa-solid fa-check-circle"></i> <span id="toast-msg">Đã lưu tự động</span>
-                </div>
-
-            </div>
-        </div>
-
-        <!-- Right Column: Info & Action -->
-        <div class="col-right">
-            <!-- Exam Meta -->
-            <div class="ca-card-featured" style="margin-bottom: 24px; text-align: center;">
-                <p class="text-caption" style="text-transform: uppercase; letter-spacing: 0.05em; margin: 0 0 8px;">Thời gian còn lại</p>
-                <div id="countdown-timer" class="timer-display">--:--</div>
-                <div style="margin-top: 12px; display: inline-flex;">
-                    <span class="status s-ongoing"><span class="status-dot"></span>Đang thi</span>
+                <div class="qmap-legend">
+                    <div class="qmap-legend-item"><div class="legend-box"></div> Chưa làm</div>
+                    <div class="qmap-legend-item"><div class="legend-box answered"></div> Đã làm</div>
+                    <div class="qmap-legend-item"><div class="legend-box current"></div> Đang chọn</div>
+                    <div class="qmap-legend-item"><div class="legend-box flagged"></div> Gắn cờ</div>
                 </div>
             </div>
 
-            <!-- Submit -->
-            <div class="ca-card" style="margin-bottom: 24px;">
-                <p class="text-h3" style="text-align: center; margin: 0 0 16px;">Hoàn tất bài làm?</p>
-                <button type="button" data-action="submit-exam" class="btn btn-primary btn-lg" style="width: 100%;">
+            {{-- Submit --}}
+            <div class="submit-block">
+                <button type="button" data-action="submit-exam" class="btn-submit">
                     Nộp bài thi
                 </button>
-                <p class="text-caption" style="text-align: center; margin: 12px 0 0;">(Không thể sửa sau khi nộp)</p>
-            </div>
-
-            <!-- Tools -->
-            <div class="ca-card">
-                <h3 class="text-h3" style="margin: 0 0 16px;">Tiện ích</h3>
-
-                <p class="text-caption" style="margin: 0 0 8px;">Cỡ chữ</p>
-                <div style="display: flex; gap: 8px; margin-bottom: 20px;">
-                    <button type="button" data-action="font-minus" class="btn btn-outline btn-sm" style="flex: 1;">A-</button>
-                    <button type="button" data-action="font-plus" class="btn btn-outline btn-sm" style="flex: 1;">A+</button>
-                </div>
-
-                <p class="text-caption" style="margin: 0 0 8px;">Giấy nháp</p>
-                <textarea class="ca-input" rows="5" placeholder="Ghi chú nhanh tại đây..."></textarea>
+                <p class="submit-note">Không thể sửa sau khi nộp</p>
             </div>
         </div>
-    </main>
+    </div>
+
+    {{-- Toast --}}
+    <div id="save-toast" class="toast">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M22 11.08V12a10 10 0 11-5.93-9.14"/><path d="M22 4L12 14.01l-3-3"/></svg>
+        <span id="toast-msg">Đã lưu tự động</span>
+    </div>
 
     <script>
         const configEl = document.getElementById('exam-config');
         const totalQuestions = parseInt(configEl?.dataset.totalQuestions || '0', 10);
         let currentQuestionIndex = 0;
-        let baseFontSize = 15;
 
         const saveUrl = "{{ route('student.exams.save-answer', $schedule->id) }}";
         const csrfToken = "{{ csrf_token() }}";
@@ -675,30 +515,37 @@ $totalQuestions = count($questions);
             const timerDisplay = document.getElementById('countdown-timer');
             const examForm = document.getElementById('exam-form');
 
+            // Question navigator
             document.querySelectorAll('[data-question-index]').forEach(btn => {
                 btn.addEventListener('click', () => {
                     goToQuestion(parseInt(btn.dataset.questionIndex || '0', 10));
                 });
             });
 
+            // Flag buttons
             document.querySelectorAll('[data-flag-index]').forEach(btn => {
                 btn.addEventListener('click', () => {
                     toggleFlag(parseInt(btn.dataset.flagIndex || '0', 10));
                 });
             });
 
+            // Option cards
             document.querySelectorAll('[data-option-index]').forEach(label => {
                 label.addEventListener('click', () => {
                     selectOption(label, parseInt(label.dataset.optionIndex || '0', 10));
                 });
             });
 
+            // Nav buttons
             document.querySelector('[data-action="prev-question"]')?.addEventListener('click', prevQuestion);
             document.querySelector('[data-action="next-question"]')?.addEventListener('click', nextQuestion);
-            document.querySelector('[data-action="submit-exam"]')?.addEventListener('click', () => examForm.submit());
-            document.querySelector('[data-action="font-minus"]')?.addEventListener('click', () => changeFontSize(-1));
-            document.querySelector('[data-action="font-plus"]')?.addEventListener('click', () => changeFontSize(1));
+            document.querySelector('[data-action="submit-exam"]')?.addEventListener('click', () => {
+                if (confirm('Bạn chắc chắn muốn nộp bài? Không thể sửa sau khi nộp.')) {
+                    examForm.submit();
+                }
+            });
 
+            // Countdown
             const countdown = setInterval(function() {
                 if (timeLeft <= 0) {
                     clearInterval(countdown);
@@ -713,11 +560,12 @@ $totalQuestions = count($questions);
                     timeLeft -= 1;
 
                     if (timeLeft < 300) {
-                        timerDisplay.style.color = '#991B1B';
+                        timerDisplay.classList.add('urgent');
                     }
                 }
             }, 1000);
 
+            // Answer change → auto-save
             document.querySelectorAll('.answer-radio').forEach(radio => {
                 radio.addEventListener('change', function() {
                     const questionIdx = this.closest('.question-container').id.split('-')[1];
@@ -727,56 +575,69 @@ $totalQuestions = count($questions);
                     autoSave(this.getAttribute('data-question-id'), this.value);
                 });
             });
+
+            // Mobile panel toggle
+            const panelHandle = document.getElementById('panel-handle');
+            const zenPanel = document.getElementById('zen-panel');
+            if (panelHandle && zenPanel) {
+                panelHandle.addEventListener('click', () => {
+                    zenPanel.classList.toggle('expanded');
+                });
+            }
+
+            // Keyboard navigation
+            document.addEventListener('keydown', function(e) {
+                if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+                    e.preventDefault();
+                    prevQuestion();
+                } else if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+                    e.preventDefault();
+                    nextQuestion();
+                }
+            });
         });
 
         function updateAnsweredCount() {
-            const answered = document.querySelectorAll('.question-btn.answered').length;
+            const answered = document.querySelectorAll('.q-btn.answered').length;
             document.getElementById('answered-count').innerText = answered;
         }
 
         let toastTimeout;
-
         function showToast(message, type = 'success') {
             toastMsg.innerText = message;
             toastEl.className = 'toast show';
             if (type === 'error') toastEl.classList.add('error');
             if (type === 'warning') toastEl.classList.add('warning');
-
             clearTimeout(toastTimeout);
-            toastTimeout = setTimeout(() => {
-                toastEl.classList.remove('show');
-            }, 2500);
+            toastTimeout = setTimeout(() => toastEl.classList.remove('show'), 2500);
         }
 
         function autoSave(questionId, optionId) {
             showToast('Đang lưu...', 'warning');
-
             fetch(saveUrl, {
-                    method: "POST",
-                    headers: {
-                        "Content-Type": "application/json",
-                        "X-CSRF-TOKEN": csrfToken
-                    },
-                    body: JSON.stringify({
-                        question_id: questionId,
-                        question_option_id: optionId,
-                        tab_switch_count: tabSwitchCount
-                    })
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    "X-CSRF-TOKEN": csrfToken
+                },
+                body: JSON.stringify({
+                    question_id: questionId,
+                    question_option_id: optionId,
+                    tab_switch_count: tabSwitchCount
                 })
-                .then(res => res.json())
-                .then(data => {
-                    if (data.success) {
-                        showToast('Đã lưu bài tự động', 'success');
-                    } else {
-                        showToast('Không thể lưu!', 'error');
-                    }
-                })
-                .catch(() => {
-                    showToast('Lỗi kết nối!', 'error');
-                });
+            })
+            .then(res => res.json())
+            .then(data => {
+                if (data.success) {
+                    showToast('Đã lưu tự động', 'success');
+                } else {
+                    showToast('Không thể lưu!', 'error');
+                }
+            })
+            .catch(() => showToast('Lỗi kết nối!', 'error'));
         }
 
-        // ── Anti-cheat: Tab switch tracking ──────────────────
+        // Anti-cheat: Tab switch tracking
         let tabSwitchCount = 0;
         document.addEventListener('visibilitychange', function() {
             if (document.hidden) {
@@ -787,24 +648,18 @@ $totalQuestions = count($questions);
 
         function goToQuestion(index) {
             if (index < 0 || index >= totalQuestions) return;
-
             document.getElementById(`question-${currentQuestionIndex}`).classList.remove('active');
             document.getElementById(`nav-btn-${currentQuestionIndex}`).classList.remove('current');
-
             currentQuestionIndex = index;
             document.getElementById(`question-${currentQuestionIndex}`).classList.add('active');
             document.getElementById(`nav-btn-${currentQuestionIndex}`).classList.add('current');
-
             updateNavigationButtons();
+            // Scroll question nav button into view
+            document.getElementById(`nav-btn-${currentQuestionIndex}`).scrollIntoView({ block: 'nearest', behavior: 'smooth' });
         }
 
-        function prevQuestion() {
-            goToQuestion(currentQuestionIndex - 1);
-        }
-
-        function nextQuestion() {
-            goToQuestion(currentQuestionIndex + 1);
-        }
+        function prevQuestion() { goToQuestion(currentQuestionIndex - 1); }
+        function nextQuestion() { goToQuestion(currentQuestionIndex + 1); }
 
         function updateNavigationButtons() {
             document.getElementById('btn-prev').disabled = (currentQuestionIndex === 0);
@@ -820,24 +675,12 @@ $totalQuestions = count($questions);
         function toggleFlag(index) {
             const navBtn = document.getElementById(`nav-btn-${index}`);
             const flagBtn = document.getElementById(`flag-btn-${index}`);
-
             const isFlagged = navBtn.classList.toggle('flagged');
-
-            if (isFlagged) {
-                flagBtn.innerHTML = '<i class="fa-solid fa-flag" style="color: #D97706;"></i> <span style="color: #D97706;">Bỏ cờ</span>';
-            } else {
-                flagBtn.innerHTML = '<i class="fa-regular fa-flag"></i> Đặt cờ';
+            const label = flagBtn.querySelector('.flag-label');
+            if (label) {
+                label.textContent = isFlagged ? 'Bỏ cờ' : 'Đặt cờ';
             }
-        }
-
-        function changeFontSize(direction) {
-            baseFontSize += (direction * 2);
-            if (baseFontSize < 13) baseFontSize = 13;
-            if (baseFontSize > 24) baseFontSize = 24;
-
-            document.querySelectorAll('.question-text-content').forEach(el => {
-                el.style.fontSize = `${baseFontSize}px`;
-            });
+            flagBtn.classList.toggle('active', isFlagged);
         }
     </script>
 </body>

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -106,6 +106,12 @@ Route::middleware(['auth', 'must_change_password_handled'])->group(function () {
         // Danh sách lớp học phần của sinh viên
         Route::get('/classes', [StudentPageController::class, 'classes'])->name('classes.index');
 
+        // Chi tiết lớp học phần (Class Workspace)
+        Route::get('/classes/{section}', [StudentPageController::class, 'classShow'])->name('classes.show');
+
+        // Khiếu nại
+        Route::get('/complaints', [StudentPageController::class, 'complaints'])->name('complaints.index');
+
         Route::get('/schedules/{schedule}', [\App\Http\Controllers\Student\ExamController::class, 'show'])->name('exams.show');
         Route::post('/schedules/{schedule}/start', [\App\Http\Controllers\Student\ExamController::class, 'start'])->name('exams.start');
         Route::get('/schedules/{schedule}/room', [\App\Http\Controllers\Student\ExamController::class, 'room'])->name('exams.room');


### PR DESCRIPTION
#### Không gian 1: Sidebar toàn cục (Global Navigation):
- Khác với giảng viên có thể bỏ Dashboard, **Sinh viên bắt buộc phải có dashboard**. Vì họ học 5-6 môn cùng lúc, họ cần một nơi tổng hợp mọi deadlines.

    - **Tổng quan (Dashboard)**: Nơi quan trọng nhất. Hiển thị các khối thông minh mang tính cấp bách: - Kỳ thi sắp tới (Dùng card màu nổi hoặc viền đỏ để cảnh báo). - Thông báo mới nhất từ tất cả các lớp.
    - **Lớp học của tôi(Menu xổ xuống)**: Giống giảng viên, bấm vào sẽ xổ ra danh sách các lớp đang theo trong học kì hiện tại để truy cập nhanh.
    - **Kết quả học tập**: Xem bảng điểm tổng hợp của tất cả các môn qua các học kỳ.
    - **Khiếu nại**: Nơi theo dõi tiến trình xử lý các đơn khiếu nại (đang chờ, đã giải quyết). #### Không gian 2: Chi tiết Lớp học (Class Workspace - Tab ngang):
- Khi sinh viên bấm vào môn bất kì hiển thị trên sidebar trước đó, họ vào không gian của lớp đó. Cấu trúc Tab ngang sẽ tương đồng với giảng viên để tạo sự nhất quán cho hệ thống:
    - **Header**: Tên lớp học phần, giảng viên phụ trách.
    - **Tab 1 - Bảng tin (Feed)**: Các thông báo, bài đăng của giảng viên, tài liệu môn học.
    - **Tab 2 - Kỳ thi**: Danh sách các đề thi của riêng môn này. Phân loại rõ ràng bằng Badge trạng thái: Sắp mở, Đang diễn ra (Nút "vào thi" sáng lên), Đã nộp, Đã có điểm.
    - **Tab 3 - Điểm số**: Xem chi tiết điểm chuyên cần, giữa kỳ, cuối kỳ môn này. #### Không gian 3: Phòng thi(Zen mode/ Distraction-free)
- Đây là màn hình "Sống còn" của sinh viên (student/exams/room.blade.php). Khi sinh viên bấm "Vào thi", giao diện phải chuyển sang chế độ **Zen Mode**:
    - **Ép đóng Sidebar & Navbar**: Ẩn hoàn toàn menu bên trái và menu trên cùng để sinh viên không bấm nhầm thoát ra ngoài.
    - **Bố cục 2 cột (Tỉ lệ 8-2 hoặc 7-3)**:
        - **Cột trái (Lớn)**: Khu vực hiển thị nội dung câu hỏi hiện tại và các đáp án (A, B, C, D). Sử dụng khoảng trắng lớn (whitespace) để chống mỏi mắt. Form chọn đáp án dùng input có viền xanh rõ ràng khi :focus.
        -  **Cột phải (Nhỏ, ghim cố định**): * Đồng hồ đếm ngược to, rõ ràng (chuyển sang màu đỏ khi còn < 5 phút).
            - Bản đồ câu hỏi (Grid các ô vuông 1, 2, 3...): Ô đã làm tô màu Xanh, ô chưa làm màu Trắng, ô đang chọn có viền Đậm.
            - Nút **"Nộp bài"** (Dùng btn-primary), luôn hiển thị ở góc dưới. #### Không gian 4: Luồng xem điểm & Khiếu nại (Cross-Navigation):
- Chúng ta lại tận dụng Modal/Slide-over ở đây để quy trình trơn tru nhất:
    - Kịch bản: Sinh viên đang ở Tab "Điểm số" của môn Toán CC. Thấy điểm thi cuối kỳ là 4.0, họ muốn phúc khảo.
    - Hành động: Ngay cạnh điểm 4.0, có một nút nhỏ btn-ghost "Gửi khiếu nại".
    - Thực thi: Bấm vào nút -> Bật lên một <x-modal>. Trong Modal có sẵn thông tin: Môn: Toán CC, Bài thi: Cuối kỳ, Điểm hiện tại: 4.0. Sinh viên chỉ việc nhập lý do vào textarea và ấn "Gửi".
    - Gửi xong, Modal đóng lại. Trạng thái kế bên điểm 4.0 đổi thành Badge "Đang phúc khảo". Không cần phải nhảy sang một trang Khiếu nại riêng biệt nào cả.